### PR TITLE
CSS Inlining

### DIFF
--- a/config/critters-webpack-plugin.js
+++ b/config/critters-webpack-plugin.js
@@ -235,7 +235,7 @@ function getElementsByTagName(tagName) {
 const ElementExtensions = {
   nodeName: {
     get() {
-      return this.tagName;
+      return this.tagName.toUpperCase();
     }
   },
   insertBefore(child, referenceNode) {
@@ -279,7 +279,12 @@ const DocumentExtensions = {
   // nwmatcher requires that it at least report a correct nodeType of DOCUMENT_NODE.
   nodeType: {
     get() {
-      return 11;
+      return 9;
+    }
+  },
+  nodeName: {
+    get() {
+      return '#document';
     }
   },
   createElement(name) {
@@ -295,10 +300,10 @@ const DocumentExtensions = {
     return node;
   },
   querySelector(sel) {
-    return this.$match.first(sel);
+    return this.$match.first(sel, this.documentElement);
   },
   querySelectorAll(sel) {
-    return this.$match.select(sel);
+    return this.$match.select(sel, this.documentElement);
   },
   getElementsByTagName,
   // nwmatcher uses inexistence of `document.addEventListener` to detect IE:

--- a/config/critters-webpack-plugin.js
+++ b/config/critters-webpack-plugin.js
@@ -26,6 +26,10 @@ const PARSE5_OPTS = {
 module.exports = class CrittersWebpackPlugin {
   constructor(options) {
     this.options = options || {};
+    this.urlFilter = this.options.filter;
+    if (this.urlFilter instanceof RegExp) {
+      this.urlFilter = this.urlFilter.test.bind(this.urlFilter);
+    }
   }
 
   /** Invoked by Webpack during plugin initialization */

--- a/config/critters-webpack-plugin.js
+++ b/config/critters-webpack-plugin.js
@@ -21,7 +21,7 @@ const PARSE5_OPTS = {
  *  @param {Object} options
  *  @param {Boolean} [options.external=true]  Fetch and inline critical styles from external stylesheets
  *  @param {Boolean} [options.async=false]    Convert critical-inlined external stylesheets to load asynchronously (via link rel="preload")
- *  @param {Boolean} [options.minify=false]   Minify resulting critical CSS using cssnano (note: this often doesn't result in further size reduction)
+ *  @param {Boolean} [options.compress=true]  Compress resulting critical CSS
  */
 module.exports = class CrittersWebpackPlugin {
   constructor(options) {
@@ -132,15 +132,7 @@ module.exports = class CrittersWebpackPlugin {
       }
     });
 
-    sheet = css.stringify(ast, { compress: true });
-
-    // Adding the `minify:true` option runs the resulting critical CSS through cssnano.
-    if (this.options.minify) {
-      const cssnano = require('cssnano');
-      done = cssnano.process(sheet, {}, { preset: 'default' }).then((result) => {
-        sheet = result.css;
-      });
-    }
+    sheet = css.stringify(ast, { compress: this.options.compress!==false });
 
     return done.then(() => {
       // If all rules were removed, get rid of the style element entirely

--- a/config/critters-webpack-plugin.js
+++ b/config/critters-webpack-plugin.js
@@ -212,22 +212,14 @@ function defineProperties(obj, properties) {
 
 /** {document,Element}.getElementsByTagName() is the only traversal method required by nwmatcher. */
 function getElementsByTagName(tagName) {
-  const stack = [this];
-  const matches = [];
-  const isWildCard = tagName === '*';
-  const tagNameUpper = tagName.toUpperCase();
-  while (stack.length !== 0) {
-    const el = stack.pop();
-    let child = el.lastChild;
-    while (child) {
-      if (child.nodeType === 1) stack.push(child);
-      child = child.previousSibling;
-    }
-    if (isWildCard || (el.tagName != null && (el.tagName === tagNameUpper || el.tagName.toUpperCase() === tagNameUpper))) {
-      matches.push(el);
-    }
-  }
-  return matches;
+  // Only return Element/Document nodes
+  if (this.nodeType!==1 && this.nodeType!==9 || this.type==='directive') return [];
+  return Array.prototype.concat.apply(
+    // Add current element if it matches tag
+    (tagName === '*' || (this.tagName && (this.tagName == tagName || this.nodeName === tagName.toUpperCase()))) ? [this] : [],
+    // Check children recursively
+    this.children.map(child => getElementsByTagName.call(child, tagName))
+  );
 }
 
 

--- a/config/critters-webpack-plugin.js
+++ b/config/critters-webpack-plugin.js
@@ -126,25 +126,14 @@ module.exports = class CrittersWebpackPlugin {
           sel = sel.replace(/::?(?:[a-z-]+)([.[#~&^:*]|\s|\n|$)/gi, '$1');
           return document.querySelector(sel, document) != null;
         });
-        // If there are no matched selectors, replace the rule with a comment.
+        // If there are no matched selectors, remove the rule:
         if (rule.selectors.length===0) {
-          rule.type = 'comment';
-          rule.comment = '';
-          delete rule.selectors;
-          delete rule.declarations;
+          return false;
         }
       }
 
-      if (rule.rules) {
-        // Filter out comments
-        rule.rules = rule.rules.filter(notComment);
-        // If there are no remaining rules, replace the parent rule with a comment.
-        if (rule.rules.length===0) {
-          rule.type = 'comment';
-          rule.comment = '';
-          delete rule.rules;
-        }
-      }
+      // If there are no remaining rules, remove the whole rule.
+      return !rule.rules || rule.rules.length!==0;
     });
 
     sheet = css.stringify(ast, { compress: this.options.compress!==false });

--- a/config/critters-webpack-plugin.js
+++ b/config/critters-webpack-plugin.js
@@ -20,7 +20,8 @@ const PARSE5_OPTS = {
  *  @class
  *  @param {Object} options
  *  @param {Boolean} [options.external=true]  Fetch and inline critical styles from external stylesheets
- *  @param {Boolean} [options.async=false]    Convert critical-inlined external stylesheets to load asynchronously (via link rel="preload")
+ *  @param {Boolean} [options.async=false]    Convert critical-inlined external stylesheets to load asynchronously (via link rel="preload" - see https://filamentgroup.com/lab/async-css.html)
+ *  @param {Boolean} [options.preload=false]  (requires `async` option) Append a new <link rel="stylesheet"> into <body> instead of swapping the preload's rel attribute
  *  @param {Boolean} [options.compress=true]  Compress resulting critical CSS
  */
 module.exports = class CrittersWebpackPlugin {
@@ -99,7 +100,14 @@ module.exports = class CrittersWebpackPlugin {
       if (this.options.async) {
         link.setAttribute('rel', 'preload');
         link.setAttribute('as', 'style');
-        link.setAttribute('onload', "this.rel='stylesheet'");
+        if (this.options.preload) {
+          const bodyLink = document.createElement('link');
+          bodyLink.setAttribute('rel', 'stylesheet');
+          bodyLink.setAttribute('href', href);
+          document.body.appendChild(bodyLink);
+        } else {
+          link.setAttribute('onload', "this.rel='stylesheet'");
+        }
       }
     });
   }

--- a/config/critters-webpack-plugin.js
+++ b/config/critters-webpack-plugin.js
@@ -18,7 +18,7 @@ const PARSE5_OPTS = {
  *  @param {Object} options
  *  @param {Boolean} [options.external=true]  Fetch and inline critical styles from external stylesheets
  *  @param {Boolean} [options.async=false]    Convert critical-inlined external stylesheets to load asynchronously (via link rel="preload")
- *  @param {Boolean} [options.minify=false]   Minify resulting critical CSS using cssnano
+ *  @param {Boolean} [options.minify=false]   Minify resulting critical CSS using cssnano (note: this often doesn't result in further size reduction)
  */
 module.exports = class CrittersWebpackPlugin {
   constructor(options) {

--- a/config/html-webpack-inline-critical-css-plugin.js
+++ b/config/html-webpack-inline-critical-css-plugin.js
@@ -153,7 +153,7 @@ module.exports = class HtmlWebpackInlineCriticalCssPlugin {
     visit(ast, function (rule) {
       if (rule.type==='rule') {
         rule.selectors = rule.selectors.filter(function (sel) {
-          if (sel.match(/:(hover|focus|active)([.[#~&^:*]|\s|\n|$)/)) return false;
+          // Remove unknown pseudos as they break nwmatcher
           sel = sel.replace(/::?(?:[a-z-]+)([.[#~&^:*]|\s|\n|$)/gi, '$1');
           return document.querySelector(sel, document) != null;
         });

--- a/config/html-webpack-inline-critical-css-plugin.js
+++ b/config/html-webpack-inline-critical-css-plugin.js
@@ -13,8 +13,8 @@ const PARSE5_OPTS = {
 };
 
 function defineProperties(obj, properties) {
-  for (let i in properties) {
-    let value = properties[i];
+  for (const i in properties) {
+    const value = properties[i];
     Object.defineProperty(obj, i, typeof value === 'function' ? { value: value } : value);
   }
 }
@@ -65,9 +65,9 @@ const DocumentExtensions = {
     return treeUtils.createElement(name, null, []);
   },
   createTextNode: function (text) {
-    let scratch = this.$$scratchElement;
+    const scratch = this.$$scratchElement;
     treeUtils.insertText(scratch, text);
-    let node = scratch.lastChild;
+    const node = scratch.lastChild;
     treeUtils.detachNode(node);
     return node;
   },
@@ -97,8 +97,8 @@ module.exports = class HtmlWebpackInlineCriticalCssPlugin {
         defineProperties(document, DocumentExtensions);
         document.documentElement = document.childNodes[document.childNodes.length - 1];
 
-        let scratch = document.$$scratchElement = document.createElement('div');
-        let elementProto = Object.getPrototypeOf(scratch);
+        const scratch = document.$$scratchElement = document.createElement('div');
+        const elementProto = Object.getPrototypeOf(scratch);
         defineProperties(elementProto, ElementExtensions);
         elementProto.ownerDocument = document;
 
@@ -109,15 +109,14 @@ module.exports = class HtmlWebpackInlineCriticalCssPlugin {
           USE_HTML5: false
         });
 
-        let externalSheets;
-        externalSheets = document.querySelectorAll('link[rel="stylesheet"]');
+        const externalSheets = document.querySelectorAll('link[rel="stylesheet"]');
 
         Promise.all(externalSheets.map(function(link) {
           const href = link.getAttribute('href');
           if (href.match(/^(https?:)?\/\//)) return Promise.resolve();
           const filename = path.resolve(outputPath, href.replace(/^\//, ''));
-          let asset = compilation.assets[path.relative(outputPath, filename).replace(/^\.\//, '')];
-          let promise = asset ? Promise.resolve(asset.source()) : readFile(filename);
+          const asset = compilation.assets[path.relative(outputPath, filename).replace(/^\.\//, '')];
+          const promise = asset ? Promise.resolve(asset.source()) : readFile(filename);
           return promise.then(function (sheet) {
             const style = document.createElement('style');
             style.$$name = href;
@@ -147,9 +146,9 @@ module.exports = class HtmlWebpackInlineCriticalCssPlugin {
     let sheet = style.childNodes.length>0 && style.childNodes.map(getNodeValue).join('\n');
     if (!sheet) return done;
 
-    let ast = css.parse(sheet);
+    const ast = css.parse(sheet);
 
-    let before = sheet;
+    const before = sheet;
 
     visit(ast, function (rule) {
       if (rule.type==='rule') {
@@ -237,12 +236,12 @@ function notComment(rule) {
 }
 
 function getElementsByTagName(tagName) {
-  let stack = [this];
-  let matches = [];
-  let isWildCard = tagName === '*';
-  let tagNameUpper = tagName.toUpperCase();
+  const stack = [this];
+  const matches = [];
+  const isWildCard = tagName === '*';
+  const tagNameUpper = tagName.toUpperCase();
   while (stack.length !== 0) {
-    let el = stack.pop();
+    const el = stack.pop();
     let child = el.lastChild;
     while (child) {
       if (child.nodeType === 1) stack.push(child);

--- a/config/html-webpack-inline-critical-css-plugin.js
+++ b/config/html-webpack-inline-critical-css-plugin.js
@@ -1,0 +1,406 @@
+const fs = require('fs');
+const path = require('path');
+// const jsdom = require('jsdom');
+// const cssTree = require('css-tree');
+const parse5 = require('parse5');
+const nwmatcher = require('nwmatcher');
+const css = require('css');
+
+const treeUtils = parse5.treeAdapters.htmlparser2;
+
+const PLUGIN_NAME = 'html-webpack-inline-critical-css-plugin';
+
+const PARSE5_OPTS = {
+  treeAdapter: treeUtils
+};
+
+function defineProperties(obj, properties) {
+  for (let i in properties) {
+    let value = properties[i];
+    Object.defineProperty(obj, i, typeof value === 'function' ? { value: value } : value);
+  }
+}
+
+const ElementExtensions = {
+  nodeName: {
+    get: function() {
+      return this.tagName;
+    }
+  },
+  appendChild: function (child) {
+    treeUtils.appendChild(this, child);
+    return child;
+  },
+  removeChild: function (child) {
+    treeUtils.detachNode(child);
+  },
+  setAttribute: function (name, value) {
+    if (this.attribs == null) this.attribs = {};
+    if (value == null) value = '';
+    this.attribs[name] = value;
+  },
+  removeAttribute: function(name) {
+    if (this.attribs != null) {
+      delete this.attribs[name];
+    }
+  },
+  getAttribute: function (name) {
+    return this.attribs != null && this.attribs[name];
+  },
+  hasAttribute: function (name) {
+    return this.attribs != null && this.attribs[name] != null;
+  },
+  getAttributeNode: function (name) {
+    const value = this.getAttribute(name);
+    if (value!=null) return { specified: true, value: value };
+  },
+  getElementsByTagName: getElementsByTagName
+};
+
+const DocumentExtensions = {
+  nodeType: {
+    get: function () {
+      return 11;
+    }
+  },
+  createElement: function (name) {
+    return treeUtils.createElement(name, null, []);
+  },
+  createTextNode: function (text) {
+    let scratch = this.$$scratchElement;
+    treeUtils.insertText(scratch, text);
+    let node = scratch.lastChild;
+    treeUtils.detachNode(node);
+    return node;
+  },
+  querySelector: function (sel) {
+    return this.$match.first(sel);
+  },
+  querySelectorAll: function (sel) {
+    return this.$match.select(sel);
+  },
+  getElementsByTagName: getElementsByTagName,
+  // https://github.com/dperini/nwmatcher/blob/3edb471e12ce7f7d46dc1606c7f659ff45675a29/src/nwmatcher.js#L353
+  addEventListener: Object
+};
+
+module.exports = class HtmlWebpackInlineCriticalCssPlugin {
+  constructor(options) {
+    this.options = options || {};
+  }
+
+  apply(compiler) {
+    const self = this;
+    const outputPath = compiler.options.output.path;
+    compiler.hooks.compilation.tap(PLUGIN_NAME, function (compilation) {
+      compilation.hooks.htmlWebpackPluginAfterHtmlProcessing.tapAsync(PLUGIN_NAME, function (htmlPluginData, callback) {
+        const document = parse5.parse(htmlPluginData.html, PARSE5_OPTS);
+
+        defineProperties(document, DocumentExtensions);
+        document.documentElement = document.childNodes[document.childNodes.length - 1];
+
+        let scratch = document.$$scratchElement = document.createElement('div');
+        let elementProto = Object.getPrototypeOf(scratch);
+        defineProperties(elementProto, ElementExtensions);
+        // Object.assign(elementProto, ElementExtensions);
+        elementProto.ownerDocument = document;
+
+        document.$match = nwmatcher({ document });
+        document.$match.configure({
+          CACHING: false,
+          USE_QSAPI: false,
+          USE_HTML5: false
+        });
+
+        // const head = document.$match.byTag('head');
+
+        let externalSheets;
+        externalSheets = document.querySelectorAll('link[rel="stylesheet"]');
+
+        Promise.all(externalSheets.map(function(link) {
+          const href = link.getAttribute('href');
+          if (href.match(/^(https?:)?\/\//)) return Promise.resolve();
+          const filename = path.resolve(outputPath, href.replace(/^\//, ''));
+          // console.log('>>>> '+ filename);
+          let asset = compilation.assets[path.relative(outputPath, filename).replace(/^\.\//, '')];
+          let promise = asset ? Promise.resolve(asset.source()) : readFile(filename);
+          return promise.then(function (sheet) {
+            const style = document.createElement('style');
+            style.$$name = href;
+            style.appendChild(document.createTextNode(sheet));
+            // head.appendChild(style);
+            link.parentNode.appendChild(style);  // @TODO insertBefore
+          });
+        }))
+          .then(function() {
+            const styles = document.$match.byTag('style');
+            return Promise.all(styles.map(function (style) {
+              return self.processStyle(style, document);
+            }));
+          })
+          .then(function () {
+            const html = parse5.serialize(document, PARSE5_OPTS);
+            callback(null, { html });
+          })
+          .catch(function (err) {
+            callback(err);
+          });
+
+        // for (let i = 0; i < styles.length; i++) {
+        //   this.processStyle(styles[i], document);
+        // }
+
+        // const html = parse5.serialize(document);
+        // return { html };
+
+        /*
+        const dom = new jsdom.JSDOM(htmlPluginData.html);
+        const styles = dom.window.document.querySelectorAll('style');
+        for (let i=0; i<styles.length; i++) {
+          this.processStyle(styles[i]);
+        }
+        // this.processDom(dom.window.document);
+        let html = dom.serialize();
+        return { html };
+        */
+      });
+    });
+  }
+
+  processStyle(style, document) {
+    let done = Promise.resolve();
+    let sheet = style.childNodes.length>0 && style.childNodes.map(getNodeValue).join('\n');
+    if (!sheet) return done;
+
+    // let ast = cssTree.parse(sheet, {
+    //   positions: false,
+    //   // parseRulePrelude: false,
+    //   // parseAtrulePrelude: false,
+    //   parseValue: false
+    // });
+    // cssTree.walk(ast, {
+    //   visit: 'Rule',
+    //   enter(node, item, list) {
+    //     console.log(this);
+    //     if (node.prelude && node.prelude.type === 'SelectorList' && document.querySelector(cssTree.generate(node.prelude)) == null) {
+    //       list.remove(item);
+    //     }
+    //     // if (node.type === 'Selector') {
+    //     // }
+    //   }
+    // });
+    // sheet = cssTree.generate(ast);
+
+    let ast = css.parse(sheet);
+
+    let before = sheet;
+
+    visit(ast, function (rule) {
+      if (rule.type==='rule') {
+        rule.selectors = rule.selectors.filter(function (sel) {
+          if (sel.match(/:(hover|focus|active)([.[#~&^:*]|\s|\n|$)/)) return false;
+          sel = sel.replace(/::?(?:[a-z-]+)([.[#~&^:*]|\s|\n|$)/gi, '$1');
+          return document.querySelector(sel, document) != null;
+        });
+        // If there are no matched selectors, replace the rule with a comment.
+        if (rule.selectors.length===0) {
+          rule.type = 'comment';
+          rule.comment = '';
+          delete rule.selectors;
+          delete rule.declarations;
+        }
+      }
+
+      if (rule.rules) {
+        // Filter out comments
+        rule.rules = rule.rules.filter(notComment);
+        // If there are no remaining rules, replace the parent rule with a comment.
+        if (rule.rules.length===0) {
+          rule.type = 'comment';
+          rule.comment = '';
+          delete rule.rules;
+        }
+      }
+    });
+
+    sheet = css.stringify(ast, { compress: true });
+
+    if (this.options.minimize || this.options.compress || this.options.minify) {
+      const cssnano = require('cssnano');
+      done = cssnano.process(sheet, {}, { preset: 'default' }).then(function (result) {
+        sheet = result.css;
+      });
+    }
+
+    return done.then(function () {
+      if (sheet.trim().length===0) {
+        // all rules were removed, get rid of the style element entirely
+        sheet.parentNode.removeChild(sheet);
+      }
+      else {
+        // replace the stylesheet inline
+        while (style.lastChild) {
+          style.removeChild(style.lastChild);
+        }
+        style.appendChild(document.createTextNode(sheet));
+      }
+      const name = style.$$name;
+      console.log('\u001b[32mInlined CSS Size' + (name ? (' ('+name+')') : '') + ': ' + (sheet.length / 1000).toPrecision(2) + 'kb (' + ((before.length - sheet.length) / before.length * 100 | 0) + '% of original ' + (before.length / 1000).toPrecision(2) + 'kb)\u001b[39m');
+    });
+
+    /*
+    console.dir(style);
+    if (style.sheet == null) return;
+
+    const document = style.ownerDocument;
+
+    // function serializeStyle(styleDeclaration) {
+    //   let str = '';
+    //   for (let i=0; i<styleDeclaration.length; i++) {
+    //     if (i!==0) str += ' ';
+    //     str += styleDeclaration[i];
+    //     str += ':';
+    //     str += styleDeclaration.getPropertyValue(styleDeclaration[i]);
+    //     str += ';';
+    //   }
+    //   return str;
+    // }
+
+    function selectorExists(selector) {
+      return document.querySelector(selector)!=null;
+    }
+
+    function processRule(out, rule) {
+      let str = '',
+        hasRules = false,
+        key = rule.keyText,
+        sel = rule.selectorText,
+        media = rule.conditionText;
+
+      if (key != null) {
+        str += key + '{';
+      }
+      else if (sel != null) {
+        if (!selectorExists(sel)) return out;
+        str += sel + '{';
+      }
+      else if (media != null) {
+        if (!document.defaultView.matchMedia(media).matches) return out;
+        str += media + '{';
+      }
+
+      if (rule.cssRules != null && rule.cssRules.length) {
+        let innerRules = rule.cssRules.reduce(processRule, '');
+        if (innerRules.length !== 0) {
+          hasRules = true;
+          str += innerRules;
+        }
+      }
+
+      if (rule.style != null && rule.style.length) {
+        hasRules = true;
+        str += rule.style.cssText;
+      }
+
+      if (hasRules) {
+        str += '}';
+        out += str;
+      }
+      return out;
+
+      // let str = '';
+      // switch (rule.type) {
+      // case 1:
+      //   str = sel + '{' + serializeStyle(rule.style) + '}';
+      //   break;
+      // case 4:
+      //   str = rule.conditionText + '{' +  + '}';
+      //   break;
+      // case 7:
+      //   str = rule.cssText.replace(/\s*\{[\s\S]*$/g);
+      //   break;
+      // }
+      // out += str;
+      // return out;
+    }
+
+    let processedStyles = [].slice.call(style.sheet.cssRules).reduce(processRule, '');
+
+    if (processedStyles) {
+      let c;
+      while ((c = style.lastChild)) style.removeChild(c);
+      style.appendChild(document.createTextNode(processedStyles));
+    }
+    else {
+      style.parentNode.removeChild(style);
+    }
+
+    */
+  }
+};
+
+
+function visit(node, fn) {
+  if (node.stylesheet) return visit(node.stylesheet, fn);
+
+  node.rules.forEach(function (rule) {
+    // @media etc
+    if (rule.rules) {
+      visit(rule, fn);
+      // fn(rule);
+      // return;
+    }
+
+    // keyframes
+    // if (rule.keyframes) {
+    //   rule.keyframes.forEach( keyframe => {
+    //     if (keyframe.type == 'keyframe') {
+    //       fn(keyframe, rule);
+    //     }
+    //   });
+    //   return;
+    // }
+
+    // @charset, @import etc
+    // if (!rule.declarations && !rule.keyframes) return;
+
+    fn(rule);
+  });
+}
+
+
+function readFile(file) {
+  return new Promise(function (resolve, reject) {
+    fs.readFile(file, 'utf8', function (err, contents) {
+      if (err) reject(err);
+      else resolve(contents);
+    });
+  });
+}
+
+function getNodeValue(node) {
+  return node.nodeValue;
+}
+
+function notComment(rule) {
+  return rule.type !== 'comment';
+}
+
+function getElementsByTagName(tagName) {
+  let stack = [this];
+  let matches = [];
+  let isWildCard = tagName === '*';
+  let tagNameUpper = tagName.toUpperCase();
+  while (stack.length !== 0) {
+    let el = stack.pop();
+    let child = el.lastChild;
+    while (child) {
+      if (child.nodeType === 1) stack.push(child);
+      child = child.previousSibling;
+    }
+    if (isWildCard || (el.tagName != null && (el.tagName === tagNameUpper || el.tagName.toUpperCase() === tagNameUpper))) {
+      matches.push(el);
+    }
+  }
+  return matches;
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
         2,
         2
       ],
-      "react/prefer-stateless-function": 0
+      "object-shorthand": 0,
+      "prefer-arrow-callback": 0
     }
   },
   "eslintIgnore": [
@@ -34,8 +35,10 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "babel-preset-env": "^1.6.1",
     "babel-register": "^6.26.0",
+    "chalk": "^2.3.2",
     "clean-webpack-plugin": "^0.1.19",
     "copy-webpack-plugin": "^4.5.1",
+    "css": "^2.2.1",
     "css-loader": "^0.28.11",
     "ejs-loader": "^0.3.1",
     "eslint": "^4.18.2",
@@ -48,6 +51,8 @@
     "jsdom": "^11.6.2",
     "mini-css-extract-plugin": "^0.3.0",
     "node-sass": "^4.7.2",
+    "nwmatcher": "^1.4.4",
+    "parse5": "^4.0.0",
     "preact-render-to-string": "^3.7.0",
     "preload-webpack-plugin": "github:GoogleChromeLabs/preload-webpack-plugin",
     "progress-bar-webpack-plugin": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         2
       ],
       "object-shorthand": 0,
-      "prefer-arrow-callback": 0
+      "prefer-arrow-callback": 0,
+      "prefer-const": 1
     }
   },
   "eslintIgnore": [

--- a/package.json
+++ b/package.json
@@ -9,14 +9,19 @@
     "lint": "eslint src"
   },
   "eslintConfig": {
-    "extends": "eslint-config-developit",
+    "extends": [
+      "standard",
+      "standard-jsx"
+    ],
     "rules": {
       "indent": [
         2,
         2
       ],
-      "object-shorthand": 0,
-      "prefer-arrow-callback": 0,
+      "semi": [
+        2,
+        "always"
+      ],
       "prefer-const": 1
     }
   },
@@ -43,7 +48,13 @@
     "css-loader": "^0.28.11",
     "ejs-loader": "^0.3.1",
     "eslint": "^4.18.2",
-    "eslint-config-developit": "^1.1.1",
+    "eslint-config-standard": "^11.0.0",
+    "eslint-config-standard-jsx": "^5.0.0",
+    "eslint-plugin-import": "^2.10.0",
+    "eslint-plugin-node": "^6.0.1",
+    "eslint-plugin-promise": "^3.7.0",
+    "eslint-plugin-react": "^7.7.0",
+    "eslint-plugin-standard": "^3.0.1",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "fork-ts-checker-notifier-webpack-plugin": "^0.4.0",
     "fork-ts-checker-webpack-plugin": "^0.4.1",

--- a/src/index.html
+++ b/src/index.html
@@ -1,16 +1,23 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<title>Squoosh</title>
-		<meta name="viewport" content="width=device-width,initial-scale=1">
-		<meta name="mobile-web-app-capable" content="yes">
-		<meta name="apple-mobile-web-app-capable" content="yes">
-		<meta name="theme-color" content="#673ab8">
-		<link rel="manifest" href="/manifest.json">
-	</head>
-	<body>
-		<div id="app" prerender></div>
-		<!-- <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" /> -->
-	</body>
+  <head>
+    <meta charset="utf-8">
+    <title>Squoosh</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="theme-color" content="#673ab8">
+    <link rel="manifest" href="/manifest.json">
+  </head>
+  <body>
+    <div id="app" prerender></div>
+    <script>
+      (function(style){
+        style.rel='stylesheet'
+        style.href='https://fonts.googleapis.com/icon?family=Material+Icons'
+        document.head.appendChild(style)
+      })(document.createElement('link'));
+    </script>
+    <!-- <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" /> -->
+  </body>
 </html>

--- a/src/lib/fix-pmc.js
+++ b/src/lib/fix-pmc.js
@@ -3,17 +3,17 @@ import { options } from 'preact';
 const classNameDescriptor = {
   enumerable: false,
   configurable: true,
-  get() {
+  get () {
     return this.class;
   },
-  set(value) {
+  set (value) {
     this.class = value;
   }
 };
 
-let old = options.vnode;
+const old = options.vnode;
 options.vnode = vnode => {
-  let a = vnode.attributes;
+  const a = vnode.attributes;
   if (a != null) {
     if ('className' in a) {
       a.class = a.className;

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -1,7 +1,7 @@
 // @import './material-icons.scss';
 // @import 'material-components-web/material-components-web';
 @import './reset.scss';
-@import url('https://fonts.googleapis.com/icon?family=Material+Icons');
+// @import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 
 html, body {
   height: 100%;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ const PreloadWebpackPlugin = require('preload-webpack-plugin');
 const ReplacePlugin = require('webpack-plugin-replace');
 const CopyPlugin = require('copy-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
-const HtmlInlineCssPlugin = require('./config/html-webpack-inline-critical-css-plugin');
+const CrittersPlugin = require('./config/critters-webpack-plugin');
 const WatchTimestampsPlugin = require('./config/watch-timestamps-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
@@ -175,8 +175,11 @@ module.exports = function(_, env) {
 
       // Inject <link rel="preload"> for resources
       isProd && new PreloadWebpackPlugin(),
-      isProd && new HtmlInlineCssPlugin(),
 
+      isProd && new CrittersPlugin({
+        // convert critical'd <link rel="stylesheet"> to <link rel="preload" as="style" onload="this.rel='stylesheet'">
+        async: true
+      }),
 
       // Inline constants during build, so they can be folded by UglifyJS.
       new webpack.DefinePlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,8 +177,10 @@ module.exports = function(_, env) {
       isProd && new PreloadWebpackPlugin(),
 
       isProd && new CrittersPlugin({
-        // convert critical'd <link rel="stylesheet"> to <link rel="preload" as="style" onload="this.rel='stylesheet'">
-        async: true
+        // convert critical'd <link rel="stylesheet"> to <link rel="preload" as="style">:
+        async: true,
+        // copy original <link rel="stylesheet"> to the end of <body>:
+        preload: true
       }),
 
       // Inline constants during build, so they can be folded by UglifyJS.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ const PreloadWebpackPlugin = require('preload-webpack-plugin');
 const ReplacePlugin = require('webpack-plugin-replace');
 const CopyPlugin = require('copy-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
+const HtmlInlineCssPlugin = require('./config/html-webpack-inline-critical-css-plugin');
 const WatchTimestampsPlugin = require('./config/watch-timestamps-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
@@ -174,6 +175,8 @@ module.exports = function(_, env) {
 
       // Inject <link rel="preload"> for resources
       isProd && new PreloadWebpackPlugin(),
+      isProd && new HtmlInlineCssPlugin(),
+
 
       // Inline constants during build, so they can be folded by UglifyJS.
       new webpack.DefinePlugin({


### PR DESCRIPTION
This adds a new plugin (which I think could be released on its own, and I have a funny name for). It plugs into the output of `html-webpack-plugin`, finds inline & external stylesheets, inlines them, then trims out selectors & rules not used by the document.

In this app, the effect is a drop from 13kb to 1.2kb of critical CSS.

(note: currently targeted at `app-skeleton` branch)

Still to do:

- [x] If the stylesheet being inlined is external, replace the `<link>` tag with an async one (preload -> style).

/cc @surma 