### PR TITLE
Allow mouse wheel on two-up handle. Fixes #49

### DIFF
--- a/src/components/output/index.tsx
+++ b/src/components/output/index.tsx
@@ -65,8 +65,9 @@ export default class Output extends Component<Props, State> {
   onRetargetableEvent(event: Event) {
     const targetEl = event.target as HTMLElement;
     if (!this.pinchZoomLeft) throw Error('Missing pinch-zoom element');
-    // If the event is on the handle of the two-up, let it through.
-    if (targetEl.closest('.' + twoUpHandle)) return;
+    // If the event is on the handle of the two-up, let it through,
+    // unless it's a wheel event, in which case always let it through.
+    if (event.type !== 'wheel' && targetEl.closest('.' + twoUpHandle)) return;
     // If we've already retargeted this event, let it through.
     if (this.retargetedEvents.has(event)) return;
     // Stop the event in its tracks.


### PR DESCRIPTION
DO NOT MERGE.

This is blocked on https://github.com/GoogleChromeLabs/squoosh/pull/39. I'll rebase once that merges.

Ready for review though. One line change.