### PR TITLE
Adding browser's webp encoder

### DIFF
--- a/src/codecs/browser-webp/encoder.ts
+++ b/src/codecs/browser-webp/encoder.ts
@@ -1,0 +1,21 @@
+import { canvasEncode } from '../../lib/util';
+
+export interface EncodeOptions { quality: number; }
+export interface EncoderState { type: typeof type; options: EncodeOptions; }
+
+export const type = 'browser-webp';
+export const label = 'Browser WebP';
+export const mimeType = 'image/webp';
+export const extension = 'webp';
+export const defaultOptions: EncodeOptions = { quality: 0.5 };
+
+export async function featureTest() {
+  const data = new ImageData(1, 1);
+  const blob = await encode(data, defaultOptions);
+  if (!blob) return false;
+  return blob.type === mimeType;
+}
+
+export function encode(data: ImageData, { quality }: EncodeOptions) {
+  return canvasEncode(data, mimeType, quality);
+}

--- a/src/codecs/browser-webp/encoder.ts
+++ b/src/codecs/browser-webp/encoder.ts
@@ -12,7 +12,9 @@ export const defaultOptions: EncodeOptions = { quality: 0.5 };
 export async function featureTest() {
   const data = new ImageData(1, 1);
   const blob = await encode(data, defaultOptions);
+  // According to the spec, the blob should be null if the format isn't supported…
   if (!blob) return false;
+  // …but Safari falls back to PNG, so we need to check the mime type.
   return blob.type === mimeType;
 }
 

--- a/src/codecs/browser-webp/options.ts
+++ b/src/codecs/browser-webp/options.ts
@@ -1,0 +1,3 @@
+import qualityOption from '../generic/quality-option';
+
+export default qualityOption({ min: 0, max: 1, step: 0 });

--- a/src/codecs/encoders.ts
+++ b/src/codecs/encoders.ts
@@ -4,6 +4,10 @@ import * as browserPNG from './browser-png/encoder';
 import * as browserJPEG from './browser-jpeg/encoder';
 import * as browserWebP from './browser-webp/encoder';
 
+export interface EncoderSupportMap {
+  [key: string]: boolean;
+}
+
 export type EncoderState =
   identity.EncoderState | mozJPEG.EncoderState | browserPNG.EncoderState |
   browserJPEG.EncoderState | browserWebP.EncoderState;
@@ -21,3 +25,16 @@ export const encoderMap = {
 };
 
 export const encoders = Array.from(Object.values(encoderMap));
+
+/** Does this browser support a given encoder? Indexed by label */
+export const encodersSupported = Promise.resolve().then(async () => {
+  const encodersSupported: EncoderSupportMap = {};
+
+  await Promise.all(encoders.map(async (encoder) => {
+    // If the encoder provides a featureTest, call it, otherwise assume supported.
+    const isSupported = !('featureTest' in encoder) || await encoder.featureTest();
+    encodersSupported[encoder.type] = isSupported;
+  }));
+
+  return encodersSupported;
+});

--- a/src/codecs/encoders.ts
+++ b/src/codecs/encoders.ts
@@ -2,12 +2,14 @@ import * as mozJPEG from './mozjpeg/encoder';
 import * as identity from './identity/encoder';
 import * as browserPNG from './browser-png/encoder';
 import * as browserJPEG from './browser-jpeg/encoder';
+import * as browserWebP from './browser-webp/encoder';
 
 export type EncoderState =
-  identity.EncoderState | mozJPEG.EncoderState | browserPNG.EncoderState | browserJPEG.EncoderState;
+  identity.EncoderState | mozJPEG.EncoderState | browserPNG.EncoderState |
+  browserJPEG.EncoderState | browserWebP.EncoderState;
 export type EncoderOptions =
   identity.EncodeOptions | mozJPEG.EncodeOptions | browserPNG.EncodeOptions |
-  browserJPEG.EncodeOptions;
+  browserJPEG.EncodeOptions | browserWebP.EncodeOptions;
 export type EncoderType = keyof typeof encoderMap;
 
 export const encoderMap = {
@@ -15,6 +17,7 @@ export const encoderMap = {
   [mozJPEG.type]: mozJPEG,
   [browserPNG.type]: browserPNG,
   [browserJPEG.type]: browserJPEG,
+  [browserWebP.type]: browserWebP,
 };
 
 export const encoders = Array.from(Object.values(encoderMap));

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -18,7 +18,6 @@ import {
     EncoderType,
     EncoderOptions,
     encoderMap,
-    encodersSupported,
 } from '../../codecs/encoders';
 
 interface SourceImage {

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -13,7 +13,13 @@ import * as identity from '../../codecs/identity/encoder';
 import * as browserPNG from '../../codecs/browser-png/encoder';
 import * as browserJPEG from '../../codecs/browser-jpeg/encoder';
 import * as browserWebP from '../../codecs/browser-webp/encoder';
-import { EncoderState, EncoderType, EncoderOptions, encoderMap } from '../../codecs/encoders';
+import {
+    EncoderState,
+    EncoderType,
+    EncoderOptions,
+    encoderMap,
+    encodersSupported,
+} from '../../codecs/encoders';
 
 interface SourceImage {
   file: File;
@@ -56,7 +62,7 @@ async function compressImage(
       case browserPNG.type: return browserPNG.encode(source.data, encodeData.options);
       case browserJPEG.type: return browserJPEG.encode(source.data, encodeData.options);
       case browserWebP.type: return browserWebP.encode(source.data, encodeData.options);
-      default: throw Error(`Unexpected encoder name`);
+      default: throw Error(`Unexpected encoder ${JSON.stringify(encodeData)}`);
     }
   })();
 

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -12,6 +12,7 @@ import * as mozJPEG from '../../codecs/mozjpeg/encoder';
 import * as identity from '../../codecs/identity/encoder';
 import * as browserPNG from '../../codecs/browser-png/encoder';
 import * as browserJPEG from '../../codecs/browser-jpeg/encoder';
+import * as browserWebP from '../../codecs/browser-webp/encoder';
 import { EncoderState, EncoderType, EncoderOptions, encoderMap } from '../../codecs/encoders';
 
 interface SourceImage {
@@ -54,6 +55,7 @@ async function compressImage(
       case mozJPEG.type: return mozJPEG.encode(source.data, encodeData.options);
       case browserPNG.type: return browserPNG.encode(source.data, encodeData.options);
       case browserJPEG.type: return browserJPEG.encode(source.data, encodeData.options);
+      case browserWebP.type: return browserWebP.encode(source.data, encodeData.options);
       default: throw Error(`Unexpected encoder name`);
     }
   })();

--- a/src/components/options/index.tsx
+++ b/src/components/options/index.tsx
@@ -10,7 +10,14 @@ import * as identity from '../../codecs/identity/encoder';
 import * as browserPNG from '../../codecs/browser-png/encoder';
 import * as browserJPEG from '../../codecs/browser-jpeg/encoder';
 import * as browserWebP from '../../codecs/browser-webp/encoder';
-import { EncoderState, EncoderType, EncoderOptions, encoders } from '../../codecs/encoders';
+import {
+    EncoderState,
+    EncoderType,
+    EncoderOptions,
+    encoders,
+    encodersSupported,
+    EncoderSupportMap,
+} from '../../codecs/encoders';
 
 const encoderOptionsComponentMap = {
   [mozJPEG.type]: MozJpegEncoderOptions,
@@ -27,10 +34,17 @@ interface Props {
   onOptionsChange(newOptions: EncoderOptions): void;
 }
 
-interface State {}
+interface State {
+  encoderSupportMap?: EncoderSupportMap;
+}
 
 export default class Options extends Component<Props, State> {
   typeSelect?: HTMLSelectElement;
+
+  constructor() {
+    super();
+    encodersSupported.then(encoderSupportMap => this.setState({ encoderSupportMap }));
+  }
 
   @bind
   onTypeChange(event: Event) {
@@ -42,18 +56,22 @@ export default class Options extends Component<Props, State> {
     this.props.onTypeChange(type);
   }
 
-  render({ class: className, encoderState, onOptionsChange }: Props) {
+  render({ class: className, encoderState, onOptionsChange }: Props, { encoderSupportMap }: State) {
     const EncoderOptionComponent = encoderOptionsComponentMap[encoderState.type];
 
     return (
       <div class={`${style.options}${className ? (' ' + className) : ''}`}>
         <label>
           Mode:
-          <select value={encoderState.type} onChange={this.onTypeChange}>
-            {encoders.map(encoder => (
-              <option value={encoder.type}>{encoder.label}</option>
-            ))}
-          </select>
+          {encoderSupportMap ?
+            <select value={encoderState.type} onChange={this.onTypeChange}>
+              {encoders.filter(encoder => encoderSupportMap[encoder.type]).map(encoder => (
+                <option value={encoder.type}>{encoder.label}</option>
+              ))}
+            </select>
+            :
+            <select><option>Loading…</option></select>
+          }
         </label>
         {EncoderOptionComponent &&
           <EncoderOptionComponent

--- a/src/components/options/index.tsx
+++ b/src/components/options/index.tsx
@@ -3,18 +3,21 @@ import * as style from './style.scss';
 import { bind } from '../../lib/util';
 import MozJpegEncoderOptions from '../../codecs/mozjpeg/options';
 import BrowserJPEGEncoderOptions from '../../codecs/browser-jpeg/options';
+import BrowserWebPEncoderOptions from '../../codecs/browser-webp/options';
 
-import { type as mozJPEGType } from '../../codecs/mozjpeg/encoder';
-import { type as identityType } from '../../codecs/identity/encoder';
-import { type as browserPNGType } from '../../codecs/browser-png/encoder';
-import { type as browserJPEGType } from '../../codecs/browser-jpeg/encoder';
+import * as mozJPEG from '../../codecs/mozjpeg/encoder';
+import * as identity from '../../codecs/identity/encoder';
+import * as browserPNG from '../../codecs/browser-png/encoder';
+import * as browserJPEG from '../../codecs/browser-jpeg/encoder';
+import * as browserWebP from '../../codecs/browser-webp/encoder';
 import { EncoderState, EncoderType, EncoderOptions, encoders } from '../../codecs/encoders';
 
 const encoderOptionsComponentMap = {
-  [mozJPEGType]: MozJpegEncoderOptions,
-  [identityType]: undefined,
-  [browserPNGType]: undefined,
-  [browserJPEGType]: BrowserJPEGEncoderOptions,
+  [mozJPEG.type]: MozJpegEncoderOptions,
+  [identity.type]: undefined,
+  [browserPNG.type]: undefined,
+  [browserJPEG.type]: BrowserJPEGEncoderOptions,
+  [browserWebP.type]: BrowserWebPEncoderOptions,
 };
 
 interface Props {


### PR DESCRIPTION
I made this a separate PR as it involves async feature tests. This will probably be the only encoder that has a feature test, but the patterns may be reusable for detecting decode support.