### PR TITLE
Adding clean-set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3300,6 +3300,11 @@
         "source-map": "0.5.x"
       }
     },
+    "clean-set": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/clean-set/-/clean-set-1.1.0.tgz",
+      "integrity": "sha512-eWzgp8bQMvGVdLI8k56c4G08ez9+t7J0pmBarJ0uDv8Fc5FvQL1LWxH5TmfYUCblUi3lC7/LCvQIwsgcv6BhzQ=="
+    },
     "clean-webpack-plugin": {
       "version": "0.1.19",
       "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-0.1.19.tgz",
@@ -7904,7 +7909,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -8058,7 +8063,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },
@@ -9414,7 +9419,7 @@
         },
         "onetime": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
           "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "@types/filesize": "^3.6.0",
     "classnames": "^2.2.6",
+    "clean-set": "^1.1.0",
     "comlink": "^3.0.3",
     "comlink-loader": "^1.0.0",
     "filesize": "^3.6.1",

--- a/src/components/Options/index.tsx
+++ b/src/components/Options/index.tsx
@@ -1,4 +1,6 @@
 import { h, Component } from 'preact';
+import cleanSet from 'clean-set';
+
 import * as style from './style.scss';
 import { bind } from '../../lib/util';
 import MozJpegEncoderOptions from '../../codecs/mozjpeg/options';
@@ -80,27 +82,21 @@ export default class Options extends Component<Props, State> {
   @bind
   onPreprocessorEnabledChange(event: Event) {
     const el = event.currentTarget as HTMLInputElement;
-
     const preprocessor = el.name.split('.')[0] as keyof PreprocessorState;
 
-    this.props.onPreprocessorOptionsChange({
-      ...this.props.preprocessorState,
-      [preprocessor]: {
-        ...this.props.preprocessorState[preprocessor],
-        enabled: el.checked,
-      },
-    });
+    this.props.onPreprocessorOptionsChange(
+      cleanSet(this.props.preprocessorState, `${preprocessor}.enabled`, el.checked as any),
+    );
   }
 
   @bind
   onQuantizerOptionsChange(opts: QuantizeOptions) {
-    this.props.onPreprocessorOptionsChange({
-      ...this.props.preprocessorState,
-      quantizer: {
+    this.props.onPreprocessorOptionsChange(
+      cleanSet(this.props.preprocessorState, 'quantizer', {
         ...opts,
         enabled: this.props.preprocessorState.quantizer.enabled,
-      },
-    });
+      } as any),
+    );
   }
 
   render(


### PR DESCRIPTION
**DO NOT MERGE**

I had a go at adding `cleanSet`, but looking at the diff, it doesn't seem like the thing we want.

There may be cases where we do want it, but it seems like we more frequently want something like `cleanMerge`:

```js
const newObj = cleanMerge(obj, path, objToMerge);
// Eg:
const obj = {
  foo: { enabled: true, val: 123, bar: 'hello' },
};
const newObj = cleanMerge(obj, 'foo', { enabled: false, val: 321 });
console.log(newObj.foo.enabled); // false
console.log(newObj.foo.val); // 321
console.log(newObj.foo.bar); // 'hello'
```

So in the diff:

```js
images = cleanSet(images, `${index}.file`, file as any);
images = cleanSet(images, `${index}.bmp`, bmp as any);
images = cleanSet(images, `${index}.downloadUrl`, URL.createObjectURL(file) as any);
images = cleanSet(
  images,
  `${index}.loading`,
  (images[index].loadingCounter !== loadingCounter) as any,
);
images = cleanSet(images, `${index}.loadedCounter`, loadingCounter as any);
```

Would be:

```js
images = cleanMerge(images, index, {
  file,
  bmp,
  downloadUrl: URL.createObjectURL(file),
  loading: images[index].loadingCounter !== loadingCounter,
  loadedCounter: loadingCounter,
});
```

The `cleanMerge` implementation would be something like:

```ts
export function cleanMerge<A>(source: A, keys: string | string[], toMerge: any[] | object): A {
  if (typeof keys === 'string') keys = keys.split('.');

  let last = copy(source);
  let mergedObject = last;

  const lastIndex = keys.length - 1;
  for (const [i, key] of keys.entries()) {
    if (lastIndex) {
      last[key] = Object.assign(copy(last[key]), toMerge);
    }
    else {
      last = last[key] = copy(last[key]);
    }
  }

  return mergedObject;
}

function copy<A = any[] | object>(source: A): A {
  if (Array.isArray(source)) return [...source] as any;
  return {...(source as any)};
}
```

(although I haven't tested it)