### PR TITLE
Options UI

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -20,3 +20,5 @@ declare module 'material-radial-progress';
 declare module 'classnames' {
   export default function classnames(...args: any[]): string;
 }
+
+declare module 'pako/lib/deflate';

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "^9.6.23",
+    "@types/pretty-bytes": "^5.1.0",
     "@types/webassembly-js-api": "0.0.1",
     "babel-loader": "^7.1.5",
     "babel-plugin-jsx-pragmatic": "^1.0.2",
@@ -66,11 +67,13 @@
     "classnames": "^2.2.6",
     "comlink": "^3.0.3",
     "comlink-loader": "^1.0.0",
-    "filesize": "^3.6.1",
+    "gzip-size": "^5.0.0",
     "material-components-web": "^0.32.0",
+    "pako": "^1.0.6",
     "preact": "^8.2.9",
     "preact-i18n": "^1.2.2",
     "preact-material-components": "^1.4.7",
-    "preact-router": "^2.6.1"
+    "preact-router": "^2.6.1",
+    "pretty-bytes": "^5.1.0"
   }
 }

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,5 +1,4 @@
 import { h, Component } from 'preact';
-import { partial } from 'filesize';
 
 import { bind, linkRef, bitmapToImageData } from '../../lib/util';
 import * as style from './style.scss';
@@ -43,7 +42,7 @@ interface SourceImage {
   preprocessed?: ImageData;
 }
 
-interface EncodedImage {
+export interface EncodedImage {
   bmp?: ImageBitmap;
   file?: File;
   downloadUrl?: string;
@@ -64,8 +63,6 @@ interface State {
   loading: boolean;
   error?: string;
 }
-
-const filesize = partial({});
 
 async function preprocessImage(
   source: SourceImage,
@@ -321,16 +318,8 @@ export default class App extends Component<Props, State> {
               </div>
             )}
           {images.map((image, index) => (
-            <span class={index ? style.rightLabel : style.leftLabel}>
-              {encoderMap[image.encoderState.type].label}
-              {(image.downloadUrl && image.file) && (
-                <a href={image.downloadUrl} download={image.file.name}>🔻</a>
-              )}
-              {image.file && ` - ${filesize(image.file.size)}`}
-            </span>
-          ))}
-          {images.map((image, index) => (
             <Options
+              image={image}
               class={index ? style.rightOptions : style.leftOptions}
               preprocessorState={image.preprocessorState}
               encoderState={image.encoderState}

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -312,12 +312,12 @@ export default class App extends Component<Props, State> {
           {(leftImageBmp && rightImageBmp) ? (
             <Output leftImg={leftImageBmp} rightImg={rightImageBmp} />
           ) : (
-              <div class={style.welcome}>
-                <h1>Select an image</h1>
-                <input type="file" onChange={this.onFileChange} />
-              </div>
-            )}
-          {images.map((image, index) => (
+            <div class={style.welcome}>
+              <h1>Drop, paste or select an image</h1>
+              <input type="file" onChange={this.onFileChange} />
+            </div>
+          )}
+          {(leftImageBmp && rightImageBmp) && images.map((image, index) => (
             <Options
               image={image}
               class={index ? style.rightOptions : style.leftOptions}

--- a/src/components/App/style.scss
+++ b/src/components/App/style.scss
@@ -10,52 +10,40 @@ Note: These styles are temporary. They will be replaced before going live.
   height: 100%;
   overflow: hidden;
   contain: strict;
+  display: flex;
 
-  .leftLabel,
-  .rightLabel {
-    position: fixed;
-    bottom: 0;
-    padding: 5px 10px;
-    background: rgba(0,0,0,0.5);
-    color: #fff;
-  }
 
-  .leftLabel { left: 0; }
-  .rightLabel { right: 0; }
 
   .leftOptions,
   .rightOptions {
     position: fixed;
-    bottom: 40px;
+    bottom: 1px;
   }
 
-  .leftOptions { left: 10px; }
-  .rightOptions { right: 10px; }
+  .leftOptions { left: 0px; }
+  .rightOptions { right: 0px; }
 }
 
 .welcome {
-  position: absolute;
-  display: inline-block;
-  left: 50%;
-  top: 50%;
-  padding: 20px;
-  transform: translate(-50%, -50%);
+  flex: 1;
+  align-self: center;
+  justify-self: center;
+  text-align: center;
 
   h1 {
     font-weight: inherit;
     font-size: 150%;
     text-align: center;
   }
- 
+
   input {
     display: inline-block;
     width: 16em;
-    padding: 5px;
+    padding: 10px;
     margin: 0 auto;
     -webkit-appearance: none;
-    border: 1px solid #b68c86;
-    background: #f0d3cf;
-    box-shadow: inset 0 0 1px #fff;
+    border: 1px solid var(--button-fg);
+    background: rgba(var(--button-fg-color), 0.1);
     border-radius: 3px;
     cursor: pointer;
   }

--- a/src/components/App/style.scss
+++ b/src/components/App/style.scss
@@ -49,23 +49,52 @@ Note: These styles are temporary. They will be replaced before going live.
   }
 }
 
-:global { 
+:global {
   file-drop {
     overflow: hidden;
     touch-action: none;
     height:100%;
     width:100%;
 
-    &.drop-valid {
-      transition: opacity 200ms ease-in-out, background-color 200ms;
-      opacity: 0.5;
-      background-color:green;
+    &:after {
+      content: '';
+      position: absolute;
+      display: block;
+      left: 10px;
+      top: 10px;
+      right: 10px;
+      bottom: 10px;
+      border: 2px dashed #fff;
+      border-radius: 10px;
+      opacity: 0;
+      transform: scale(0.95);
+      transition: all 300ms ease, transform 300ms cubic-bezier(.6,2,.6,1);
+      pointer-events: none;
     }
 
-    &.drop-invalid {
-      transition: opacity 200ms ease-in-out, background-color 200ms;
-      opacity: 0.5;
-      background-color:red;
+    &.drop-valid:after,
+    &.drop-invalid:after {
+      opacity: 1;
+      transform: scale(1);
     }
+
+    &.drop-valid:after {
+      background-color:rgba(88, 116, 88, 0.2);
+      border-color: rgba(65, 129, 65, 0.5);
+    }
+
+    &.drop-invalid:after {
+      background-color:rgba(119, 85, 85, 0.2);
+      border-color:rgba(129, 63, 63, 0.5);
+    }
+  }
+}
+
+@keyframes drop-pop {
+  from {
+    transform: scale(0.9);
+  }
+  to {
+    transform: scale(1);
   }
 }

--- a/src/components/GzipSize.tsx
+++ b/src/components/GzipSize.tsx
@@ -1,0 +1,98 @@
+import { h, Component, PreactHTMLAttributes } from 'preact';
+import * as prettyBytes from 'pretty-bytes';
+import { blobToArrayBuffer } from '../lib/util';
+import GzipSizeWorker from '../lib/gzip-size.worker';
+
+type FileContents = string | ArrayBuffer | File | Blob;
+
+interface Props extends PreactHTMLAttributes {
+  data?: FileContents;
+  compareTo?: FileContents;
+  increaseClass?: string;
+  decreaseClass?: string;
+}
+
+interface State {
+  size?: number;
+  compareSize?: number;
+}
+
+let gzipSizeWorker: GzipSizeWorker;
+
+const CACHE = new WeakMap();
+
+async function compressedSize(rawData: FileContents): Promise<number | void> {
+  let data = rawData;
+
+  if (!gzipSizeWorker) {
+    gzipSizeWorker = await new GzipSizeWorker();
+  }
+
+  if (typeof data === 'string') {
+    data = new Blob([data]);
+  }
+  if (data instanceof Blob || data instanceof File) {
+    data = await blobToArrayBuffer(data);
+  }
+
+  if (CACHE.has(data)) {
+    return CACHE.get(data);
+  }
+
+  const size = gzipSizeWorker.gzipSize(data);
+  // cache the Promise so we dedupe in-flight requests.
+  CACHE.set(data, size);
+  return await size;
+}
+
+export default class GzipSize extends Component<Props, State> {
+  // "lock" counters for computed state properties
+  counters: Partial<State> = {};
+
+  componentDidMount() {
+    const { data, compareTo } = this.props;
+    if (data) {
+      this.computeSize('size', data);
+    }
+    if (compareTo) {
+      this.computeSize('compareSize', compareTo);
+    }
+  }
+
+  componentWillReceiveProps({ data, compareTo }: Props) {
+    if (data !== this.props.data) {
+      this.computeSize('size', data);
+    }
+    if (compareTo !== this.props.compareTo) {
+      this.computeSize('compareSize', compareTo);
+    }
+  }
+
+  async computeSize(prop: keyof State, data?: FileContents) {
+    const id = this.counters[prop] = (this.counters[prop] || 0) + 1;
+    const size = data ? await compressedSize(data) : 0;
+    if (this.counters[prop] !== id) return;
+    this.setState({ [prop]: size });
+  }
+
+  render(
+    { data, compareTo, increaseClass, decreaseClass, ...props }: Props,
+    { size, compareSize }: State,
+  ) {
+    const sizeFormatted = size ? prettyBytes(size) : '';
+    let delta;
+    if (size && compareSize) {
+      delta = (size - compareSize) / compareSize;
+    }
+    return (
+      <span title={sizeFormatted} {...props}>
+        {sizeFormatted}
+        {delta && (
+          <span class={delta > 0 ? increaseClass : decreaseClass}>
+            {Math.round(delta * 100)}%
+          </span>
+        )}
+      </span>
+    );
+  }
+}

--- a/src/components/Options/index.tsx
+++ b/src/components/Options/index.tsx
@@ -134,29 +134,8 @@ export default class Options extends Component<Props, State> {
             </a>
           )}
         </h2>
-        {encoderState.type !== 'identity' && (
-          <div>
-            <p>Quantization</p>
-            <label>
-              <input
-                name="quantizer.enable"
-                type="checkbox"
-                checked={!!preprocessorState.quantizer.enabled}
-                onChange={this.onPreprocessorEnabledChange}
-              />
-              Enable
-            </label>
-            {preprocessorState.quantizer.enabled &&
-              <QuantizerOptionsComponent
-                options={preprocessorState.quantizer}
-                onChange={this.onQuantizerOptionsChange}
-              />
-            }
-            <hr/>
-          </div>
-        )}
-        <label>
-          Mode:
+
+        <section class={style.picker}>
           {encoderSupportMap ?
             <select value={encoderState.type} onChange={this.onEncoderTypeChange}>
               {encoders.filter(encoder => encoderSupportMap[encoder.type]).map(encoder => (
@@ -166,7 +145,28 @@ export default class Options extends Component<Props, State> {
             :
             <select><option>Loading…</option></select>
           }
-        </label>
+        </section>
+
+        {encoderState.type !== 'identity' && (
+          <div key="quantization" class={style.quantization}>
+            <label class={style.toggle}>
+              <input
+                name="quantizer.enable"
+                type="checkbox"
+                checked={!!preprocessorState.quantizer.enabled}
+                onChange={this.onPreprocessorEnabledChange}
+              />
+              Enable Quantization
+            </label>
+            {preprocessorState.quantizer.enabled &&
+              <QuantizerOptionsComponent
+                options={preprocessorState.quantizer}
+                onChange={this.onQuantizerOptionsChange}
+              />
+            }
+          </div>
+        )}
+
         {EncoderOptionComponent &&
           <EncoderOptionComponent
             options={

--- a/src/components/Options/index.tsx
+++ b/src/components/Options/index.tsx
@@ -26,10 +26,15 @@ import {
     encoders,
     encodersSupported,
     EncoderSupportMap,
+    encoderMap,
 } from '../../codecs/encoders';
 import { QuantizeOptions } from '../../codecs/imagequant/quantizer';
 
 import { PreprocessorState } from '../../codecs/preprocessors';
+import { EncodedImage } from '../App';
+
+import GzipSize from '../GzipSize';
+import DownloadIcon from '../../lib/icons/Download';
 
 const encoderOptionsComponentMap = {
   [identity.type]: undefined,
@@ -48,6 +53,7 @@ const encoderOptionsComponentMap = {
 
 interface Props {
   class?: string;
+  image: EncodedImage;
   encoderState: EncoderState;
   preprocessorState: PreprocessorState;
   onEncoderTypeChange(newType: EncoderType): void;
@@ -104,7 +110,7 @@ export default class Options extends Component<Props, State> {
   }
 
   render(
-    { class: className, encoderState, preprocessorState, onEncoderOptionsChange }: Props,
+    { image, class: className, encoderState, preprocessorState, onEncoderOptionsChange }: Props,
     { encoderSupportMap }: State,
   ) {
     // tslint:disable variable-name
@@ -112,6 +118,22 @@ export default class Options extends Component<Props, State> {
 
     return (
       <div class={`${style.options}${className ? (' ' + className) : ''}`}>
+        <h2 class={style.title}>
+          {className && className.match(/left/) ? 'Left Image' : 'Right Image'}
+          {', '}
+          {encoderMap[encoderState.type].label}
+
+          {(image.downloadUrl && image.file) && (
+            <a
+              class={style.download}
+              href={image.downloadUrl}
+              download={image.file.name}
+              title="Download"
+            >
+              <DownloadIcon />
+            </a>
+          )}
+        </h2>
         {encoderState.type !== 'identity' && (
           <div>
             <p>Quantization</p>
@@ -155,6 +177,14 @@ export default class Options extends Component<Props, State> {
             onChange={onEncoderOptionsChange}
           />
         }
+
+        <div class={style.sizeDetails}>
+          <GzipSize
+            // @todo: once we have a nice way to pass down the original image
+            // (image size?), pass compareTo prop here to show size delta.
+            data={image.file}
+          />
+        </div>
       </div>
     );
   }

--- a/src/components/Options/style.scss
+++ b/src/components/Options/style.scss
@@ -3,34 +3,59 @@ Note: These styles are temporary. They will be replaced before going live.
 */
 
 .options {
-    width: 180px;
-    padding: 10px;
-    background: rgba(50,50,50,0.8);
-    border: 1px solid #222;
-    box-shadow: inset 0 0 1px #fff, 0 0 1px #fff;
-    border-radius: 3px;
-    color: #eee;
-    overflow: auto;
-    z-index: 1;
-    transition: opacity 300ms ease;
+  box-sizing: border-box;
+  width: 250px;
+  padding: 0;
+  background: rgba(40,40,40,0.9);
+  box-shadow: 0 0 3px rgba(0,0,0,0.3);
+  border-radius: 1px 1px 5px 5px;
+  color: #eee;
+  overflow: auto;
+  z-index: 1;
+  opacity: 0.9;
+  transform-origin: 50% 140%;
+  transition: opacity 300ms linear;
+  animation: options-open 500ms cubic-bezier(.6,1.6,.6,1) forwards 1;
 
-    &:not(:hover) {
-        opacity: .6;
+  &:hover, &:focus, &:focus-within {
+    opacity: 1;
+  }
+
+  @keyframes options-open {
+    from {
+      transform: translateY(100px) scale(.8);
     }
+  }
 
-    label {
-        display: block;
-        padding: 5px;
-        font-weight: bold;
+  .picker {
+    margin: 5px 15px;
 
-        select {
-            margin-left: 5px;
-        }
+    select {
+      display: block;
+      width: 100%;
+      box-sizing: border-box;
+      -webkit-appearance: none;
+      appearance: none;
+      padding: 10px 30px 10px 10px;
+      background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="25" height="5"><polygon fill="#fff" points="10,0 5,5 0,0"/></svg>') right center no-repeat;
+      background-color: var(--gray-dark);
+      opacity: 0.9;
+      border: none;
+      font: inherit;
+      color: white;
+      transition: box-shadow 150ms ease;
 
-        input {
-            vertical-align: middle;
-        }
+      &:hover {
+        opacity: 1;
+      }
+      &:focus {
+        opacity: 1;
+        outline: none;
+        box-shadow: 0 0 0 2px var(--button-fg, #ccc);
+      }
     }
+  }
+
   .title {
     display: flex;
     align-items: center;
@@ -61,13 +86,64 @@ Note: These styles are temporary. They will be replaced before going live.
     }
   }
 
+  label {
+    display: block;
+    padding: 5px;
+    margin: 0 10px;
+
+    input {
+        vertical-align: middle;
+    }
+
+    input[type=checkbox],
+    input[type=radio] {
+      margin-right: 8px;
+    }
+
+    range-input {
+      display: block;
+      width: 90%;
+    }
+  }
 
   .size-details {
     padding: 5px 15px;
     background: rgba(0,0,0,0.5);
   }
+}
 
-    pre {
-        font-size: 10px;
+
+.quantization {
+  padding: 5px 0;
+  margin: 5px 0;
+  box-shadow: inset 0 -.5px 0 rgba(0,0,0,0.25), 0 .5px 0 rgba(255,255,255,0.15);
+
+  .toggle {
+    display: flex;
+    position: relative;
+    align-content: center;
+    font-size: 14px;
+
+    input {
+      appearance: none;
+      -webkit-appearance: none;
+      width: 0;
+      height: 0;
+      margin-top: 6px;
+      border-top: 7px solid #fff;
+      border-right: 7px solid transparent;
+      border-left: 7px solid transparent;
+      // background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><polygon fill="#fff" points="10,2 5,8 0,2"/></svg>') center no-repeat;
+      transition: transform 300ms ease;
+
+      &:focus {
+        outline: none;
+        border-top-color: var(--button-fg);
+      }
+
+      &:not(:checked) {
+        transform: rotate(-90deg);
+      }
     }
+  }
 }

--- a/src/components/Options/style.scss
+++ b/src/components/Options/style.scss
@@ -31,6 +31,41 @@ Note: These styles are temporary. They will be replaced before going live.
             vertical-align: middle;
         }
     }
+  .title {
+    display: flex;
+    align-items: center;
+    padding: 10px 15px;
+    margin: 0 0 12px;
+    background: rgba(0,0,0,0.9);
+    font: inherit;
+
+    .download {
+      flex: 0;
+      margin: 0 0 0 auto;
+      background: rgba(0,0,0,0.7);
+      border-radius: 50%;
+      padding: 5px;
+      width: 16px;
+      height: 16px;
+      text-decoration: none;
+
+      > svg {
+        width: 16px;
+        height: 16px;
+        fill: #fff;
+      }
+
+      &:hover {
+        background-color: rgba(255,255,255,0.3);
+      }
+    }
+  }
+
+
+  .size-details {
+    padding: 5px 15px;
+    background: rgba(0,0,0,0.5);
+  }
 
     pre {
         font-size: 10px;

--- a/src/components/Output/custom-els/TwoUp/index.ts
+++ b/src/components/Output/custom-els/TwoUp/index.ts
@@ -30,6 +30,7 @@ export default class TwoUp extends HTMLElement {
   constructor () {
     super();
     this._handle.className = styles.twoUpHandle;
+    this._handle.setAttribute('two-up-handle', '');
 
     // Watch for children changes.
     // Note this won't fire for initial contents,

--- a/src/components/Output/index.tsx
+++ b/src/components/Output/index.tsx
@@ -168,6 +168,7 @@ export default class Output extends Component<Props, State> {
     if (event.type !== 'wheel' && targetEl.closest('.' + twoUpHandle)) return;
     // If we've already retargeted this event, let it through.
     if (this.retargetedEvents.has(event)) return;
+    if (event.type === 'pointerdown') this.pinchZoomLeft.focus();
     // Stop the event in its tracks.
     event.stopImmediatePropagation();
     event.preventDefault();
@@ -194,7 +195,11 @@ export default class Output extends Component<Props, State> {
           onMouseDownCapture={this.onRetargetableEvent}
           onWheelCapture={this.onRetargetableEvent}
         >
-          <pinch-zoom onChange={this.onPinchZoomLeftChange} ref={linkRef(this, 'pinchZoomLeft')}>
+          <pinch-zoom
+            tabIndex={-1}
+            onChange={this.onPinchZoomLeftChange}
+            ref={linkRef(this, 'pinchZoomLeft')}
+          >
             <canvas
               class={style.outputCanvas}
               ref={linkRef(this, 'canvasLeft')}

--- a/src/components/Output/style.scss
+++ b/src/components/Output/style.scss
@@ -15,12 +15,176 @@ Note: These styles are temporary. They will be replaced before going live.
 .output {
   @extend %fill;
 
+  --background-color: rgba(0,0,0,0.05);
+  background-color: #fff;
+  background-repeat: repeat;
+  background-image:
+    linear-gradient(45deg, var(--background-color) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--background-color) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--background-color) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--background-color) 75%);
+  background-size: 20px 20px;
+  background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+  transition: background-color 300ms ease;
+
+  &.altBackground {
+    background-color: #777;
+  }
+
   > two-up {
     @extend %fill;
 
+    [two-up-handle] {
+      background: #43CEF1;
+      box-shadow: inset 4px 0 0 #34B9EB, 0 1px 4px rgba(0,0,0,0.5);
+      cursor: ew-resize;
+      width: 9px;
+
+      &:after {
+        width: 62px;
+        height: 56px;
+        background: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="30" height="20" fill="none"><path fill="#34B9EB" d="M10 0v20L0 10zM20 0v20l10-10z"/></svg>') center no-repeat #fff;
+        border: 1px solid rgba(0,0,0,0.12);
+        border-radius: 5px;
+        box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+        transform-origin: 50% 50%;
+        transition: all 300ms ease;
+
+        /*
+        // use a smaller thumb on larger screens?
+        @media (min-width: 600px) {
+          transform: translate(-50%, -50%) scale(0.75);
+        }
+        */
+      }
+
+      &:hover:after,
+      &:active:after {
+        // box-shadow: 0 3px 7px rgba(0,0,0,0.3);
+        background-color: #fafafa;
+        border-color: #34B9EB;
+      }
+  }
+
     > pinch-zoom {
       @extend %fill;
+      outline: none;
     }
+  }
+}
+
+.controls {
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  left: 220px;
+  right: 220px;
+  bottom: 0;
+  padding: 9px;
+  overflow: hidden;
+  flex-wrap: wrap;
+  contain: content;
+
+  @media (max-width: 680px) {
+    top: 0;
+    bottom: auto;
+    left: 0;
+    right: 0;
+  }
+
+  > * {
+    z-index: 2;
+  }
+
+  .group {
+    flex: 0;
+    display: flex;
+    justify-items: center;
+    align-items: space-around;
+    flex-wrap: nowrap;
+  }
+
+  .button,
+  .zoom {
+    display: flex;
+    align-items: center;
+    flex: 0;
+    box-sizing: border-box;
+    height: 48px;
+    padding: 0 16px;
+    margin: 4px;
+    background-color: #fff;
+    border: 1px solid rgba(0,0,0,0.2);
+    border-radius: 5px;
+    line-height: 1;
+    font-size: 110%;
+    white-space: nowrap;
+
+    &:focus {
+      box-shadow: 0 0 0 2px var(--button-fg);
+      outline: none;
+      z-index: 1;
+    }
+  }
+
+  .icon {
+    display: inline-block;
+    flex: 1;
+    font-size: 24px;
+    fill: var(--button-fg);
+  }
+
+  .button {
+    text-transform: uppercase;
+    color: var(--button-fg);
+    cursor: pointer;
+
+    // svg {
+    //   color: var(--button-fg);
+    // }
+  }
+
+  .button.icon-left .icon {
+    padding-right: 6px;
+  }
+
+  .button:hover {
+    background-color: #eee;
+  }
+
+  .zoom {
+    flex: 0 0 6em;
+    color: #625E80;
+    font: inherit;
+    cursor: text;
+    width: 6em;
+    text-align: center;
+    justify-content: center;
+
+    &:focus {
+      box-shadow: inset 0 1px 4px rgba(0,0,0,0.2), 0 0 0 2px var(--button-fg);
+    }
+
+    strong {
+      position: relative;
+      top: 1px;
+      margin: 0 3px 0 0;
+      color: #888;
+      font-weight: normal;
+      border-bottom: 1px dashed #999;
+    }
+  }
+
+  .group > :not(:first-child) {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    margin-left: 0;
+  }
+  .group > :not(:last-child) {
+    margin-right: 0;
+    border-right-width: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
   }
 }
 

--- a/src/lib/gzip-size.worker.ts
+++ b/src/lib/gzip-size.worker.ts
@@ -1,0 +1,7 @@
+import { gzip } from 'pako/lib/deflate';
+
+export default class GzipSizeWorker {
+  gzipSize(data: string | ArrayBuffer) {
+    return gzip(data).length;
+  }
+}

--- a/src/lib/icons/Download.tsx
+++ b/src/lib/icons/Download.tsx
@@ -1,0 +1,10 @@
+import { h } from 'preact';
+import { memoizedComponent } from '../memoized-component';
+
+// @todo double check this will work with Uglify DCE
+export default memoizedComponent(() => (
+  // tslint:disable:max-line-length
+  <svg width="24" height="24" viewBox="0 0 24 24">
+    <path d="M19.35 10.04A7.49 7.49 0 0 0 12 4C9.11 4 6.6 5.64 5.35 8.04A5.994 5.994 0 0 0 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM17 13l-5 5-5-5h3V9h4v4h3z" />
+  </svg>
+));

--- a/src/lib/icons/Toggle.tsx
+++ b/src/lib/icons/Toggle.tsx
@@ -1,0 +1,10 @@
+import { h } from 'preact';
+import { memoizedComponent } from '../memoized-component';
+
+// @todo double check this will work with Uglify DCE
+export default memoizedComponent(() => (
+  // tslint:disable:max-line-length
+  <svg width="24" height="24" viewBox="0 0 24 24">
+    <path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm2 4v-2H3c0 1.1.89 2 2 2zM3 9h2V7H3v2zm12 12h2v-2h-2v2zm4-18H9c-1.11 0-2 .9-2 2v10c0 1.1.89 2 2 2h10c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 12H9V5h10v10zm-8 6h2v-2h-2v2zm-4 0h2v-2H7v2z" />
+  </svg>
+));

--- a/src/lib/memoized-component.ts
+++ b/src/lib/memoized-component.ts
@@ -1,0 +1,15 @@
+import { cloneElement, Component } from 'preact';
+
+export function memoizedComponent(fn: () => JSX.Element) {
+  let cached: JSX.Element;
+  return class extends Component<any> {
+    shouldComponentUpdate(props: any) {
+      for (const i in props) if (props[i] !== this.props[i]) return true;
+      return false;
+    }
+    render (props: JSX.HTMLAttributes) {
+      if (!cached) cached = fn();
+      return cloneElement(cached, props);
+    }
+  };
+}

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -25,6 +25,15 @@ export function bind(target: any, propertyKey: string, descriptor: PropertyDescr
   };
 }
 
+/** Compare two objects, returning a boolean indicating if
+ *  they have the same properties and strictly equal values.
+ */
+export function shallowEqual(one: any, two: any) {
+  for (const i in one) if (one[i] !== two[i]) return false;
+  for (const i in two) if (!(i in one)) return false;
+  return true;
+}
+
 /** Creates a function ref that assigns its value to a given property of an object.
  *  @example
  *  // element is stored as `this.foo` when rendered.

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -9,8 +9,15 @@ html, body {
   width: 100%;
   padding: 0;
   margin: 0;
-  font: 14px/1.3 Roboto,'Helvetica Neue',arial,helvetica,sans-serif;
+  font: 12px/1.3 system-ui,-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
   overflow: hidden;
   overscroll-behavior: none;
   contain: strict;
+}
+
+:root {
+  --gray-dark: rgba(0,0,0,0.8);
+
+  --button-fg-color: 95, 180, 228;
+  --button-fg: rgb(95, 180, 228);
 }


### PR DESCRIPTION
Implements #76.

Notes:

- welcome screen is slightly improved, but we don't have a design for it so it's just a best-guess for now that we can build on later.
- "controls bar" (zoom tools and background toggle) is currently inlined in `<Output>`, but I'm going to extract it and amend this PR.
- When editing (compression/quantization) options, any image encoding changes (eg: encoding finished) will force the options UI to re-render from state.  This should be fixable by copying the options into state (derived state), so that the interim values are not solely held in the DOM.
- I made the `<TwoUp>` divider bar a tad smaller than the mocks.
- There's no "reset" button for the zoom, but there is a way to type in a zoom percentage. This might be fine as a fix for #114?