### PR TITLE
Reposition the TwoUp handle on resize

### DIFF
--- a/src/components/Output/custom-els/TwoUp/index.ts
+++ b/src/components/Output/custom-els/TwoUp/index.ts
@@ -19,6 +19,10 @@ export default class TwoUp extends HTMLElement {
    */
   private _position = 0;
   /**
+   * The position of the split in %.
+   */
+  private _relativePosition = 0.5;
+  /**
    * The value of _position when the pointer went down.
    */
   private _positionOnPointerStart = 0;
@@ -85,7 +89,8 @@ export default class TwoUp extends HTMLElement {
     // Set the initial position of the handle.
     requestAnimationFrame(() => {
       const bounds = this.getBoundingClientRect();
-      this._position = (this.orientation === 'vertical' ? bounds.height : bounds.width) / 2;
+      this._position = (this.orientation === 'vertical' ?
+          bounds.height : bounds.width) * this._relativePosition;
       this._setPosition();
     });
   }
@@ -146,6 +151,7 @@ export default class TwoUp extends HTMLElement {
 
     // Clamp position to element bounds.
     this._position = Math.max(0, Math.min(this._position, bounds[dimensionAxis]));
+    this._relativePosition = this._position / bounds[dimensionAxis];
     this._setPosition();
   }
 

--- a/src/components/Output/custom-els/TwoUp/index.ts
+++ b/src/components/Output/custom-els/TwoUp/index.ts
@@ -37,6 +37,10 @@ export default class TwoUp extends HTMLElement {
     new MutationObserver(() => this._childrenChange())
       .observe(this, { childList: true });
 
+    // Watch for element size changes.
+    new ResizeObserver(() => this._resetPosition())
+      .observe(this);
+
     // Watch for pointers on the handle.
     const pointerTracker: PointerTracker = new PointerTracker(this._handle, {
       start: (_, event) => {
@@ -57,7 +61,7 @@ export default class TwoUp extends HTMLElement {
 
   connectedCallback() {
     this._handle.innerHTML = `<div class="${styles.scrubber}">${
-      `<svg viewBox="0 0 20 10" fill="currentColor"><path d="M8 0v10L0 5zM12 0v10l8-5z"/></svg>`
+      '<svg viewBox="0 0 20 10" fill="currentColor"><path d="M8 0v10L0 5zM12 0v10l8-5z"/></svg>'
     }</div>`;
 
     this._childrenChange();

--- a/src/components/Output/custom-els/TwoUp/index.ts
+++ b/src/components/Output/custom-els/TwoUp/index.ts
@@ -42,7 +42,7 @@ export default class TwoUp extends HTMLElement {
       .observe(this, { childList: true });
 
     // Watch for element size changes.
-    if (window.hasOwnProperty('ResizeObserver')) {
+    if ('ResizeObserver' in window) {
       new ResizeObserver(() => this._resetPosition())
         .observe(this);
     } else {

--- a/src/components/Output/custom-els/TwoUp/index.ts
+++ b/src/components/Output/custom-els/TwoUp/index.ts
@@ -38,8 +38,12 @@ export default class TwoUp extends HTMLElement {
       .observe(this, { childList: true });
 
     // Watch for element size changes.
-    new ResizeObserver(() => this._resetPosition())
-      .observe(this);
+    if (window.hasOwnProperty('ResizeObserver')) {
+      new ResizeObserver(() => this._resetPosition())
+        .observe(this);
+    } else {
+      window.addEventListener('resize', () => this._resetPosition());
+    }
 
     // Watch for pointers on the handle.
     const pointerTracker: PointerTracker = new PointerTracker(this._handle, {

--- a/src/components/Output/custom-els/TwoUp/index.ts
+++ b/src/components/Output/custom-els/TwoUp/index.ts
@@ -89,8 +89,8 @@ export default class TwoUp extends HTMLElement {
     // Set the initial position of the handle.
     requestAnimationFrame(() => {
       const bounds = this.getBoundingClientRect();
-      this._position = (this.orientation === 'vertical' ?
-          bounds.height : bounds.width) * this._relativePosition;
+      const dimensionAxis = this.orientation === 'vertical' ? 'height' : 'width';
+      this._position = bounds[dimensionAxis] * this._relativePosition;
       this._setPosition();
     });
   }

--- a/src/components/Output/custom-els/TwoUp/missing-types.d.ts
+++ b/src/components/Output/custom-els/TwoUp/missing-types.d.ts
@@ -19,3 +19,36 @@ declare namespace JSX {
     'two-up': TwoUpAttributes;
   }
 }
+
+interface DOMRectReadOnly {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  readonly top: number;
+  readonly right: number;
+  readonly bottom: number;
+  readonly left: number;
+}
+
+declare global {
+  interface ResizeObserverCallback {
+    (entries: ResizeObserverEntry[], observer: ResizeObserver): void;
+  }
+
+  interface ResizeObserverEntry {
+    readonly target: Element;
+    readonly contentRect: DOMRectReadOnly;
+  }
+
+  interface ResizeObserver {
+    observe(target: Element): void;
+    unobserve(target: Element): void;
+    disconnect(): void;
+  }
+}
+
+declare var ResizeObserver: {
+  prototype: ResizeObserver;
+  new(callback: ResizeObserverCallback): ResizeObserver;
+};

--- a/src/components/Output/custom-els/TwoUp/missing-types.d.ts
+++ b/src/components/Output/custom-els/TwoUp/missing-types.d.ts
@@ -31,21 +31,19 @@ interface DOMRectReadOnly {
   readonly left: number;
 }
 
-declare global {
-  interface ResizeObserverCallback {
-    (entries: ResizeObserverEntry[], observer: ResizeObserver): void;
-  }
+interface ResizeObserverCallback {
+  (entries: ResizeObserverEntry[], observer: ResizeObserver): void;
+}
 
-  interface ResizeObserverEntry {
-    readonly target: Element;
-    readonly contentRect: DOMRectReadOnly;
-  }
+interface ResizeObserverEntry {
+  readonly target: Element;
+  readonly contentRect: DOMRectReadOnly;
+}
 
-  interface ResizeObserver {
-    observe(target: Element): void;
-    unobserve(target: Element): void;
-    disconnect(): void;
-  }
+interface ResizeObserver {
+  observe(target: Element): void;
+  unobserve(target: Element): void;
+  disconnect(): void;
 }
 
 declare var ResizeObserver: {


### PR DESCRIPTION
Fixes #105 
Repositions the handle for TwoUp when the element resizes.
I have 2 questions:

1. Do we have constraints on Browser compatibility? Should I include a polyfill for ResizeObserver? 
2. Making TS happy with ResizeObserver was a bit elaborate and I'm a newbie in TS - please advise if there's a better approach!