### PR TITLE
Fix <range-input disabled>

### DIFF
--- a/src/custom-els/RangeInput/index.ts
+++ b/src/custom-els/RangeInput/index.ts
@@ -3,8 +3,8 @@ import './styles.css';
 
 const RETARGETED_EVENTS = ['focus', 'blur'];
 const UPDATE_EVENTS = ['input', 'change'];
-const REFLECTED_PROPERTIES = ['name', 'min', 'max', 'step', 'value', 'disabled'];
-const REFLECTED_ATTRIBUTES = ['name', 'min', 'max', 'step', 'value', 'disabled'];
+const REFLECTED_PROPERTIES = ['name', 'min', 'max', 'step', 'value'];
+const REFLECTED_ATTRIBUTES = ['name', 'min', 'max', 'step', 'value'];
 
 class RangeInputElement extends HTMLElement {
   private _input = document.createElement('input');
@@ -35,6 +35,18 @@ class RangeInputElement extends HTMLElement {
 
   set labelPrecision(precision: string) {
     this.setAttribute('label-precision', precision);
+  }
+
+  get disabled(): boolean {
+    return this.hasAttribute('disabled');
+  }
+
+  set disabled(disabled: boolean) {
+    if (disabled) {
+      this.setAttribute('disabled', '');
+    } else {
+      this.removeAttribute('disabled');
+    }
   }
 
   connectedCallback() {

--- a/src/custom-els/RangeInput/index.ts
+++ b/src/custom-els/RangeInput/index.ts
@@ -80,10 +80,13 @@ class RangeInputElement extends HTMLElement {
 
   private _reflectAttributes() {
     this._ignoreChange = true;
-    for (const attributeName in REFLECTED_ATTRIBUTES) {
+    for (const attributeName of REFLECTED_ATTRIBUTES) {
       const attributeValue = this._input.getAttribute(attributeName);
-      if (attributeValue === null) continue;
-      this.setAttribute(attributeName, attributeValue);
+      if (attributeValue === null) {
+        this.removeAttribute(attributeName);
+      } else {
+        this.setAttribute(attributeName, attributeValue);
+      }
     }
     this._ignoreChange = false;
   }

--- a/src/custom-els/RangeInput/index.ts
+++ b/src/custom-els/RangeInput/index.ts
@@ -3,8 +3,8 @@ import './styles.css';
 
 const RETARGETED_EVENTS = ['focus', 'blur'];
 const UPDATE_EVENTS = ['input', 'change'];
-const REFLECTED_PROPERTIES = ['name', 'min', 'max', 'step', 'value'];
-const REFLECTED_ATTRIBUTES = ['name', 'min', 'max', 'step', 'value'];
+const REFLECTED_PROPERTIES = ['name', 'min', 'max', 'step', 'value', 'disabled'];
+const REFLECTED_ATTRIBUTES = ['name', 'min', 'max', 'step', 'value', 'disabled'];
 
 class RangeInputElement extends HTMLElement {
   private _input = document.createElement('input');
@@ -35,18 +35,6 @@ class RangeInputElement extends HTMLElement {
 
   set labelPrecision(precision: string) {
     this.setAttribute('label-precision', precision);
-  }
-
-  get disabled(): boolean {
-    return this.hasAttribute('disabled');
-  }
-
-  set disabled(disabled: boolean) {
-    if (disabled) {
-      this.setAttribute('disabled', '');
-    } else {
-      this.removeAttribute('disabled');
-    }
   }
 
   connectedCallback() {

--- a/src/custom-els/RangeInput/index.ts
+++ b/src/custom-els/RangeInput/index.ts
@@ -81,11 +81,10 @@ class RangeInputElement extends HTMLElement {
   private _reflectAttributes() {
     this._ignoreChange = true;
     for (const attributeName of REFLECTED_ATTRIBUTES) {
-      const attributeValue = this._input.getAttribute(attributeName);
-      if (attributeValue === null) {
-        this.removeAttribute(attributeName);
+      if (this._input.hasAttribute(attributeName)) {
+        this.setAttribute(attributeName, this._input.getAttribute(attributeName)!);
       } else {
-        this.setAttribute(attributeName, attributeValue);
+        this.removeAttribute(attributeName);
       }
     }
     this._ignoreChange = false;


### PR DESCRIPTION
This fixes the `.disabled` property reflection for range-input. Previously, only the `disabled` attribute worked.

Fixes #142.