### PR TITLE
Prevent browser pinch-zoom

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <title>Squoosh</title>
     <meta name="description" content="Compress and compare images with different codecs, right in your browser">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="theme-color" content="#673ab8">


### PR DESCRIPTION
Not normally something I'd do, but I've ended up in cases where the viewport is zoomed in and it's difficult to zoom out.

Since pinch zooming is our main interaction, it makes sense to disable the browser's.

This doesn't work in iOS10 though https://stackoverflow.com/a/38852262/123395.