### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ node_js:
 - node
 - 10
 - 8
-- 6
 cache: npm
 script: npm run build || npm run build # scss ts definitions need to be generated before an actual build


### PR DESCRIPTION
We should test all current LTS branches to ensure that Squoosh work there and can be built using them.