### PR TITLE
Fix #268 - change orientation to "any" from "portrait" in manifest.json

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Squoosh",
   "start_url": "/",
   "display": "standalone",
-  "orientation": "portrait",
+  "orientation": "any",
   "background_color": "#fff",
   "theme_color": "#f78f21",
   "icons": [


### PR DESCRIPTION
Change orientation to "any" - allowing tablet pwa users to use the app in any screen orientation.