### PR TITLE
Preventing logo image from being draggable in Edge

### DIFF
--- a/src/components/intro/index.tsx
+++ b/src/components/intro/index.tsx
@@ -90,7 +90,7 @@ export default class Intro extends Component<Props, State> {
         <div>
           <div class={style.logoSizer}>
             <div class={style.logoContainer}>
-              <img src={logo} class={style.logo} alt="Squoosh" decoding="async" />
+              <img src={logo} class={style.logo} alt="Squoosh" decoding="async" draggable="false" />
             </div>
           </div>
           <p class={style.openImageGuide}>


### PR DESCRIPTION
This is a fix for [Accidental click & drag on home screen loads logo image](https://github.com/GoogleChromeLabs/squoosh/issues/274). Microsoft Edge doesn't seem to support any of the css that's from line 5-12 that's in [this file](https://github.com/GoogleChromeLabs/squoosh/blob/master/src/style/reset.scss).

However, one thing to note is that in the section on the homepage "Or try one of these" which contains some (smaller) images, it'll allow you to drag and drop these images on Edge. However, I think this is is fine, especially since the header of that section asks you to try one of those images out.