### PR TITLE
Preventing images from being dragged in Edge

### DIFF
--- a/src/components/intro/style.scss
+++ b/src/components/intro/style.scss
@@ -48,6 +48,7 @@
 
 .logo {
   composes: abs-fill from '../../lib/util.scss';
+  pointer-events: none;
 }
 
 .open-image-guide {
@@ -144,6 +145,7 @@
 
 .demo-icon {
   composes: abs-fill from '../../lib/util.scss';
+  pointer-events: none;
 }
 
 .demo-description {


### PR DESCRIPTION
This is to fix the [Accidental click & drag on home screen loads logo image](https://github.com/GoogleChromeLabs/squoosh/issues/274) issue. Microsoft Edge doesn't support the second block of CSS in [this file](https://github.com/GoogleChromeLabs/squoosh/blob/master/src/style/reset.scss) to prevent dragging. 

While testing this I also noticed it's not just the logo image that can be dragged in Edge on the homepage, the sample images under the "Or try one of these:" section also had the same issue, although it's not as big of an issue. At first I thought this was intentional but then I noticed on other browsers those can't be dragged either so to make it consistent I prevented dragging on those too.