### PR TITLE
Specify lib for TypeScript

### DIFF
--- a/src/components/compress/custom-els/MultiPanel/index.ts
+++ b/src/components/compress/custom-els/MultiPanel/index.ts
@@ -170,7 +170,7 @@ export default class MultiPanel extends HTMLElement {
 
   private _closeAll(options: CloseAllOptions = {}): void {
     const { exceptFirst = false } = options;
-    let els = [...this.children].filter(el => el.matches('[content-expanded]')) as HTMLElement[];
+    let els = [...Array.from(this.children)].filter(el => el.matches('[content-expanded]')) as HTMLElement[];
 
     if (exceptFirst) {
       els = els.slice(1);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "jsx": "react",
     "jsxFactory": "h",
     "allowJs": false,
-    "baseUrl": "."
+    "baseUrl": ".",
+    "lib": ["dom", "webworker", "esnext"],
   },
   "exclude": ["src/sw/**/*"]
 }


### PR DESCRIPTION
This makes the typings work if you are in a worker, which the
`processor-worker` is.

(This apparently also caught an issue with the HTMLElement.children iterator)