### PR TITLE
Rotation optimise. Fixes #362

### DIFF
--- a/src/codecs/processor.ts
+++ b/src/codecs/processor.ts
@@ -20,7 +20,7 @@ import * as browserPDF from './browser-pdf/encoder';
 type ProcessorWorkerApi = import('./processor-worker').ProcessorWorkerApi;
 
 /** How long the worker should be idle before terminating. */
-const workerTimeout = 1000;
+const workerTimeout = 10000;
 
 interface ProcessingJobOptions {
   needsWorker?: boolean;

--- a/src/codecs/rotate/processor.ts
+++ b/src/codecs/rotate/processor.ts
@@ -4,10 +4,6 @@ const bpp = 4;
 
 export function rotate(data: ImageData, opts: RotateOptions): ImageData {
   const { rotate } = opts;
-
-  // Early exit if there's no transform.
-  if (rotate === 0) return data;
-
   const flipDimensions = rotate % 180 !== 0;
   const { width: inputWidth, height: inputHeight } = data;
   const outputWidth = flipDimensions ? inputHeight : inputWidth;

--- a/src/components/compress/index.tsx
+++ b/src/components/compress/index.tsx
@@ -85,12 +85,18 @@ interface UpdateImageOptions {
   skipPreprocessing?: boolean;
 }
 
-function processInput(
+async function processInput(
   data: ImageData,
   inputProcessData: InputProcessorState,
   processor: Processor,
 ) {
-  return processor.rotate(data, inputProcessData.rotate);
+  let processedData = data;
+
+  if (inputProcessData.rotate.rotate !== 0) {
+    processedData = await processor.rotate(processedData, inputProcessData.rotate);
+  }
+
+  return processedData;
 }
 
 async function preprocessImage(


### PR DESCRIPTION
Spotted that we were loading our rotation code when we didn't need to.

Also, our worker timeout was set to 1 second. It's supposed to be 10 and I have no idea when/how I managed to fuck that up.