### PR TITLE
Fixed blank text-fields with dark browser theme

### DIFF
--- a/src/components/Options/style.scss
+++ b/src/components/Options/style.scss
@@ -43,6 +43,7 @@ $horizontalPadding: 15px;
 
 .text-field {
   background: #fff;
+  color: #000;
   font: inherit;
   border: none;
   padding: 2px 0 2px 10px;


### PR DESCRIPTION
When using dark browser themes the text-fields' text-color becomes white, so the text in those white background text-fields is unreadable.

Patched text-color so that it now is readable.

Before:
![before](https://user-images.githubusercontent.com/25644731/49702145-81eaad00-fbf5-11e8-9d8a-f1f5cc305301.png)

After:
![after](https://user-images.githubusercontent.com/25644731/49702148-8747f780-fbf5-11e8-8f77-7306c56c4507.png)



