### PR TITLE
Fix download error after copy settings button is pressed

### DIFF
--- a/src/components/compress/index.tsx
+++ b/src/components/compress/index.tsx
@@ -321,7 +321,10 @@ export default class Compress extends Component<Props, State> {
     const oldSettings = this.state.sides[otherIndex];
 
     this.setState({
-      sides: cleanSet(this.state.sides, otherIndex, this.state.sides[index]),
+      sides: cleanSet(this.state.sides, otherIndex, {
+        ...this.state.sides[index],
+        downloadUrl: oldSettings.downloadUrl,
+      }),
     });
 
     const result = await this.props.showSnack('Settings copied across', {


### PR DESCRIPTION
If current slide's downloadUrl is copied to other slide's settings, then current slide's downloadUrl will be revoked.

The error can be reproduced. First click copy settings button, then click current slide's download button.