### PR TITLE
Fix buffer offset/size calculations in rotate/processor.ts

### DIFF
--- a/src/codecs/rotate/processor.ts
+++ b/src/codecs/rotate/processor.ts
@@ -11,7 +11,7 @@ export async function rotate(
 
   // Number of wasm memory pages (á 64KiB) needed to store the image twice.
   const bytesPerImage = data.width * data.height * 4;
-  const numPagesNeeded = Math.ceil(bytesPerImage * 2 / (64 * 1024) + 4);
+  const numPagesNeeded = Math.ceil((bytesPerImage * 2 + 4) / (64 * 1024));
   // Only count full pages, just to be safe.
   const numPagesAvailable = Math.floor(instance.exports.memory.buffer.byteLength / (64 * 1024));
   const additionalPagesToAllocate = numPagesNeeded - numPagesAvailable;
@@ -20,13 +20,13 @@ export async function rotate(
     instance.exports.memory.grow(additionalPagesToAllocate);
   }
   const view = new Uint8ClampedArray(instance.exports.memory.buffer);
-  view.set(data.data);
+  view.set(data.data, 4);
 
   instance.exports.rotate(data.width, data.height, opts.rotate);
 
   const flipDimensions = opts.rotate % 180 !== 0;
   return new ImageData(
-    view.slice(bytesPerImage, bytesPerImage * 2),
+    view.slice(bytesPerImage + 4, bytesPerImage * 2 + 4),
     flipDimensions ? data.height : data.width,
     flipDimensions ? data.width : data.height,
   );


### PR DESCRIPTION
This pull request modifies how rotate/processor.ts copies the image data to & from the WASM work buffer.

The Rust rotate implementation merged from #438 adds a 4 byte padding to the beginning of the WASM. Currently rotate/processor.ts copies the image data to offset `0` instead of `4`, and reads the output buffer from offset `bytesPerImage` instead of `bytesPerImage + 4`. As a result the rotated images may have some artifacts. In the following example the artifacts are visible along some sides of the rotated versions (e.g. top left corner of the 270° one):

![1](https://user-images.githubusercontent.com/19776768/52597902-e11aa700-2e5c-11e9-9e46-32b44b0e393f.png)

This pull request also makes a minor modification to how many pages are needed for the WASM buffer. Currently `4` gets added to `bytesPerImage * 2 / (64 * 1024)`, while the `4` should probably be added before the division.