### PR TITLE
Use packtracker io for bundle size reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,6 +117,27 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@packtracker/webpack-plugin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@packtracker/webpack-plugin/-/webpack-plugin-2.0.0.tgz",
+      "integrity": "sha512-sl02dU1qyd/dIIbUaaSi7cU44COAwelP8yqtgZzxrdrTYxwWTj/be6iRaBpO0oj/Rx5l5+pU0XeupKJjqLMQhA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11",
+        "minimist": "^1.2.0",
+        "omit-deep": "^0.3.0",
+        "tiny-json-http": "^7.0.2",
+        "webpack-bundle-analyzer": "^3.0.4"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -11559,6 +11580,56 @@
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
       "dev": true
     },
+    "omit-deep": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/omit-deep/-/omit-deep-0.3.0.tgz",
+      "integrity": "sha1-IcivNJm8rdKWUaIyy8rLxSRF6+w=",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.1",
+        "unset-value": "^0.1.1"
+      },
+      "dependencies": {
+        "has-value": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+          "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+          "dev": true,
+          "requires": {
+            "get-value": "^2.0.3",
+            "has-values": "^0.1.4",
+            "isobject": "^2.0.0"
+          },
+          "dependencies": {
+            "isobject": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+              "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+              "dev": true,
+              "requires": {
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "has-values": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+          "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+          "dev": true
+        },
+        "unset-value": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-0.1.2.tgz",
+          "integrity": "sha1-UGgQuGfyfCpabpsEgzYx9t5Y0xA=",
+          "dev": true,
+          "requires": {
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
+          }
+        }
+      }
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -14809,6 +14880,12 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+      "dev": true
+    },
+    "tiny-json-http": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-json-http/-/tiny-json-http-7.0.2.tgz",
+      "integrity": "sha512-5MsAvlq5tvgCY98Y7iQPmpP5ZqLzESrv/S5AwXWIvHL0Z0zVVAfWku7WC6V4rHJb+judXhd28KBnE5+FLOVYaQ==",
       "dev": true
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -16,14 +16,15 @@
     }
   },
   "devDependencies": {
+    "@packtracker/webpack-plugin": "^2.0.0",
     "@types/node": "10.12.30",
     "@types/pretty-bytes": "5.1.0",
     "@types/webassembly-js-api": "0.0.2",
     "@webcomponents/custom-elements": "1.2.1",
     "@webpack-cli/serve": "0.1.3",
     "assets-webpack-plugin": "3.9.10",
-    "chokidar": "2.1.2",
     "chalk": "2.4.2",
+    "chokidar": "2.1.2",
     "classnames": "2.2.6",
     "clean-webpack-plugin": "1.0.1",
     "comlink": "3.1.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ const VERSION = readJson('./package.json').version;
 
 module.exports = async function (_, env) {
   const isProd = env.mode === 'production';
-  const isCI = true; // process.env.CI === 'true',
+  const isCI = process.env.CI === 'true',
   const nodeModules = path.join(__dirname, 'node_modules');
   const componentStyleDirs = [
     path.join(__dirname, 'src/components'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ const VERSION = readJson('./package.json').version;
 
 module.exports = async function (_, env) {
   const isProd = env.mode === 'production';
-  const isCI = process.env.CI === 'true',
+  const isCI = process.env.CI === 'true';
   const nodeModules = path.join(__dirname, 'node_modules');
   const componentStyleDirs = [
     path.join(__dirname, 'src/components'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const HtmlPlugin = require('html-webpack-plugin');
 const ScriptExtHtmlPlugin = require('script-ext-html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
+const PacktrackerPlugin = require('@packtracker/webpack-plugin')
 const WatchTimestampsPlugin = require('./config/watch-timestamps-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const WorkerPlugin = require('worker-plugin');
@@ -25,6 +26,7 @@ const VERSION = readJson('./package.json').version;
 
 module.exports = async function (_, env) {
   const isProd = env.mode === 'production';
+  const isCI = true; // process.env.CI === 'true',
   const nodeModules = path.join(__dirname, 'node_modules');
   const componentStyleDirs = [
     path.join(__dirname, 'src/components'),
@@ -295,6 +297,12 @@ module.exports = async function (_, env) {
         inlineFonts: true,
         // (and don't lazy load them):
         preloadFonts: false
+      }),
+
+      isCI && new PacktrackerPlugin({
+        upload: true,
+        branch: process.env.TRAVIS_PULL_REQUEST_BRANCH || process.env.TRAVIS_BRANCH,
+        commit: process.env.TRAVIS_PULL_REQUEST_SHA || process.env.TRAVIS_COMMIT,
       })
     ].filter(Boolean), // Filter out any falsey plugin array entries.
 


### PR DESCRIPTION
As per #502, these changes install and configure the packtracker plugin to report bundle size stats to the [packtracker.io](https://packtracker.io) service.

Other steps that need to be taken for this to work

 - [ ] Create a project on packtracker
 - [ ] Install the GitHub App to this repo (under the "GitHub Checks" tab within packtracker)
 - [ ] Set the project token as `PT_PROJECT_TOKEN` in the CI environment
