### PR TITLE
Tests!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 cache: npm
-script: npm run build
+script: npm run build && npm run test
 after_success: npm run sizereport

--- a/README.md
+++ b/README.md
@@ -28,4 +28,15 @@ You can run the development server with:
 npm start
 ```
 
+# Tests
+Tests can be run with:
+``sh
+npm test
+``
+
+To run the tests slowed down in headful mode:
+``sh
+HEADLESS=false SLOWMO=500 npm test
+``
+
 [Squoosh]: https://squoosh.app

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,6 +88,12 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
       "dev": true
     },
+    "@pptr/testrunner": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pptr/testrunner/-/testrunner-0.5.0.tgz",
+      "integrity": "sha512-X8h5Yp57GunqOtUwBen+m7Pg0O/SpMQH8G0h8E4pLJ0DsUr285AJ8lZykXQQoL/rr4d4OuYSjiFaed7BHPXDLA==",
+      "dev": true
+    },
     "@sindresorhus/is": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -403,6 +409,15 @@
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.0.tgz",
       "integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "dev": true,
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
     },
     "ajv": {
       "version": "6.5.3",
@@ -4454,6 +4469,21 @@
         "is-symbol": "^1.0.1"
       }
     },
+    "es6-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "dev": true
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "dev": true,
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -4877,6 +4907,18 @@
         }
       }
     },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      }
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -4915,6 +4957,23 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-url-parser": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
+      "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
+      "dev": true,
+      "requires": {
+        "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
     "fastparse": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -4937,6 +4996,15 @@
       "dev": true,
       "requires": {
         "bser": "^2.0.0"
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
       }
     },
     "figgy-pudding": {
@@ -5354,8 +5422,7 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5472,8 +5539,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5515,7 +5581,6 @@
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5534,7 +5599,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5628,7 +5692,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5714,8 +5777,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5751,7 +5813,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5815,14 +5876,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6642,6 +6701,33 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
       "dev": true
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "dev": true,
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
     },
     "husky": {
       "version": "1.3.1",
@@ -10858,6 +10944,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -11808,6 +11900,12 @@
         "ipaddr.js": "1.8.0"
       }
     },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
+      "dev": true
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -11866,6 +11964,51 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "puppeteer": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.14.0.tgz",
+      "integrity": "sha512-SayS2wUX/8LF8Yo2Rkpc5nkAu4Jg3qu+OLTDSOZtisVQMB2Z5vjlY2TdPi/5CgZKiZroYIiyUN3sRX63El9iaw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "mime": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
+          "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "progress": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+          "dev": true
+        }
+      }
     },
     "q": {
       "version": "1.5.1",
@@ -12679,6 +12822,45 @@
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.5.0.tgz",
       "integrity": "sha512-Ga8c8NjAAp46Br4+0oZ2WxJCwIzwP60Gq1YPgU+39PiTVxyed/iKE/zyZI6+UlVYH5Q4PaQdHhcegIFPZTUfoQ==",
       "dev": true
+    },
+    "serve-handler": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.0.0.tgz",
+      "integrity": "sha512-2/e0+N1abV1HAN+YN8uCOPi1B0bIYaR6kRcSfzezRwszak5Yzr6QhT34XJk2Bw89rhXenqwLNJb4NnF2/krnGQ==",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "fast-url-parser": "1.1.3",
+        "mime-types": "2.1.18",
+        "minimatch": "3.0.4",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "2.2.1",
+        "range-parser": "1.2.0"
+      },
+      "dependencies": {
+        "mime-db": {
+          "version": "1.33.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+          "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.18",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+          "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+          "dev": true,
+          "requires": {
+            "mime-db": "~1.33.0"
+          }
+        },
+        "path-to-regexp": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
+          "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+          "dev": true
+        }
+      }
     },
     "serve-index": {
       "version": "1.9.1",
@@ -15654,6 +15836,15 @@
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         }
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "dev": true,
+      "requires": {
+        "fd-slicer": "~1.0.1"
       }
     },
     "yeoman-environment": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "webpack-dev-server --host 0.0.0.0 --hot",
     "build": "webpack -p",
+    "test": "node test/test.js",
     "lint": "tslint -c tslint.json  -p tsconfig.json -t verbose",
     "lintfix": "tslint -c tslint.json -p tsconfig.json -t verbose --fix 'src/**/*.{ts,tsx,js,jsx}'",
     "sizereport": "node config/size-report.js"
@@ -16,14 +17,15 @@
     }
   },
   "devDependencies": {
+    "@pptr/testrunner": "^0.5.0",
     "@types/node": "10.14.5",
     "@types/pretty-bytes": "5.1.0",
     "@types/webassembly-js-api": "0.0.3",
     "@webcomponents/custom-elements": "1.2.4",
     "@webpack-cli/serve": "0.1.5",
     "assets-webpack-plugin": "3.9.10",
-    "chokidar": "2.1.5",
     "chalk": "2.4.2",
+    "chokidar": "2.1.5",
     "classnames": "2.2.6",
     "clean-webpack-plugin": "1.0.1",
     "comlink": "3.1.1",
@@ -51,10 +53,12 @@
     "prerender-loader": "1.3.0",
     "pretty-bytes": "5.1.0",
     "progress-bar-webpack-plugin": "1.12.1",
+    "puppeteer": "^1.14.0",
     "raw-loader": "2.0.0",
     "readdirp": "3.0.0",
     "sass-loader": "7.1.0",
     "script-ext-html-webpack-plugin": "2.1.3",
+    "serve-handler": "^6.0.0",
     "source-map-loader": "0.2.4",
     "style-loader": "0.23.1",
     "terser-webpack-plugin": "1.2.3",

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,86 @@
+const {TestRunner, Reporter, Matchers} = require('@pptr/testrunner');
+const puppeteer = require('puppeteer');
+const os = require('os');
+const handler = require('serve-handler');
+const http = require('http');
+const path = require('path');
+(async () => {  
+  const server = http.createServer((request, response) => {
+    return handler(request, response, {
+      public: path.join(__dirname, '..', 'build')
+    });
+  });
+  await new Promise(x => server.listen(x));
+  const slowMo = parseInt(process.env.SLOWMO || '0');
+  const headless = (process.env.HEADLESS || 'true').toLowerCase() !== 'false';
+  const browser = await puppeteer.launch({
+    headless,
+    slowMo,
+    handleSIGINT: false,
+    handleSIGHUP: false,
+    handleSIGTERM: false
+  });
+  const runner = new TestRunner({
+    parallel: headless ? os.cpus().length : 1,
+    timeout: slowMo ? 60000 : 6000,
+  });
+
+  const {expect} = new Matchers();
+  const {describe, xdescribe, fdescribe} = runner;
+  const {it, fit, xit} = runner;
+  const {beforeAll, beforeEach, afterAll, afterEach} = runner;
+  const indexURL = `http://localhost:${server.address().port}/index.html`;
+
+  describe('Squoosh', () => {
+    beforeAll(async state => {
+      state.browserContext = await browser.createIncognitoBrowserContext();
+    });
+    afterAll(async state => {
+      await state.browserContext.close()
+    });
+
+    beforeEach(async state => {
+      state.page = await state.browserContext.newPage();
+    });
+    afterEach(async state => {
+      await state.page.close();
+    });
+
+    it('to have a title', async ({page}) => {
+      await page.goto(indexURL);
+      expect(await page.title()).toBe('Squoosh');      
+    });
+
+    it('to be able to select an image', async ({page}) => {
+      await page.goto(indexURL);
+      const fileInput = await page.$('input[type=file]');
+      await Promise.all([
+        page.waitForSelector('two-up'),
+        fileInput.uploadFile(path.join(__dirname, '..', 'src', 'assets', 'icon-small.png'))
+      ]);
+      await page.waitForFunction(() => document.title === 'icon-small.png - Squoosh');
+    });
+
+    it('should work offline', async({page, browserContext}) => {
+      await page.goto(indexURL);
+      await browserContext.waitForTarget(target => target.type() === 'service_worker');
+      await page.setOfflineMode(true);
+      await page.goto(indexURL);
+    });
+
+    it('should not have any console errors', async({page}) => {
+      const errors = [];
+      page.on('console', message => {
+        if (message.type() === 'error' || message.type() === 'warning')
+          errors.push(message.text());
+      });
+      await page.goto(indexURL);
+      expect(errors).toEqual([]);
+    })
+  });
+  
+  new Reporter(runner);
+  await runner.run();
+  await browser.close();
+  server.close();
+})();


### PR DESCRIPTION
I come bearing tests!

New dependencies:
* The `build` directory is served via [`serve-handler`](https://www.npmjs.com/package/serve-handler).
* Puppeteer is used to launch Chromium
* `@pptr/testrunner` is used to set up the basic describe/expect pattern

Right now there are 4 basic tests: The index page has a title, a file can be selected, the app works offline, and it doesn't throw a bunch of errors in the console. 

I am using `@pptr/testrunner` just because I am familiar with setting it up. I can switch to mocha or jest or jasmine or whatever if the maintainers have a preference.

The tests currently treat the app as a black box. The build version of the app compresses and optimizes all of the JavaScript code, so it is tricky to call into it from test code.

#313 