### PR TITLE
Add path aliases and tidy import declarations

### DIFF
--- a/src/codecs/browser-bmp/encoder.ts
+++ b/src/codecs/browser-bmp/encoder.ts
@@ -1,5 +1,5 @@
 import { mimeType } from './encoder-meta';
-import { canvasEncode } from '../../lib/util';
+import { canvasEncode } from 'lib/util';
 
 export function encode(data: ImageData) {
   return canvasEncode(data, mimeType);

--- a/src/codecs/browser-gif/encoder.ts
+++ b/src/codecs/browser-gif/encoder.ts
@@ -1,5 +1,5 @@
 import { mimeType } from './encoder-meta';
-import { canvasEncode } from '../../lib/util';
+import { canvasEncode } from 'lib/util';
 
 export function encode(data: ImageData) {
   return canvasEncode(data, mimeType);

--- a/src/codecs/browser-jp2/encoder.ts
+++ b/src/codecs/browser-jp2/encoder.ts
@@ -1,5 +1,5 @@
 import { mimeType } from './encoder-meta';
-import { canvasEncode } from '../../lib/util';
+import { canvasEncode } from 'lib/util';
 
 export function encode(data: ImageData) {
   return canvasEncode(data, mimeType);

--- a/src/codecs/browser-jpeg/encoder.ts
+++ b/src/codecs/browser-jpeg/encoder.ts
@@ -1,5 +1,5 @@
 import { EncodeOptions, mimeType } from './encoder-meta';
-import { canvasEncode } from '../../lib/util';
+import { canvasEncode } from 'lib/util';
 
 export function encode(data: ImageData, { quality }: EncodeOptions) {
   return canvasEncode(data, mimeType, quality);

--- a/src/codecs/browser-pdf/encoder.ts
+++ b/src/codecs/browser-pdf/encoder.ts
@@ -1,5 +1,5 @@
 import { mimeType } from './encoder-meta';
-import { canvasEncode } from '../../lib/util';
+import { canvasEncode } from 'lib/util';
 
 export function encode(data: ImageData) {
   return canvasEncode(data, mimeType);

--- a/src/codecs/browser-png/encoder.tsx
+++ b/src/codecs/browser-png/encoder.tsx
@@ -1,5 +1,5 @@
 import { mimeType } from './encoder-meta';
-import { canvasEncode } from '../../lib/util';
+import { canvasEncode } from 'lib/util';
 
 export function encode(data: ImageData) {
   return canvasEncode(data, mimeType);

--- a/src/codecs/browser-tiff/encoder.ts
+++ b/src/codecs/browser-tiff/encoder.ts
@@ -1,5 +1,5 @@
 import { mimeType } from './encoder-meta';
-import { canvasEncode } from '../../lib/util';
+import { canvasEncode } from 'lib/util';
 
 export function encode(data: ImageData) {
   return canvasEncode(data, mimeType);

--- a/src/codecs/browser-webp/encoder.ts
+++ b/src/codecs/browser-webp/encoder.ts
@@ -1,5 +1,5 @@
 import { EncodeOptions, mimeType } from './encoder-meta';
-import { canvasEncode } from '../../lib/util';
+import { canvasEncode } from 'lib/util';
 
 export function encode(data: ImageData, { quality }: EncodeOptions) {
   return canvasEncode(data, mimeType, quality);

--- a/src/codecs/decoders.ts
+++ b/src/codecs/decoders.ts
@@ -1,4 +1,5 @@
-import { nativeDecode, sniffMimeType, canDecodeImage } from '../lib/util';
+import { nativeDecode, sniffMimeType, canDecodeImage } from 'lib/util';
+
 import Processor from './processor';
 import webpDataUrl from 'url-loader!./tiny.webp';
 

--- a/src/codecs/generic/quality-option.tsx
+++ b/src/codecs/generic/quality-option.tsx
@@ -1,7 +1,10 @@
 import { h, Component } from 'preact';
-import { bind } from '../../lib/initial-util';
-import * as style from '../../components/Options/style.scss';
+
+import { bind } from 'lib/initial-util';
+
 import Range from '../../components/range';
+
+import * as style from '../../components/Options/style.scss';
 
 interface EncodeOptions {
   quality: number;

--- a/src/codecs/imagequant/options.tsx
+++ b/src/codecs/imagequant/options.tsx
@@ -1,11 +1,14 @@
 import { h, Component } from 'preact';
-import { bind } from '../../lib/initial-util';
-import { inputFieldValueAsNumber, konami, preventDefault } from '../../lib/util';
+
+import { bind } from 'lib/initial-util';
+import { inputFieldValueAsNumber, konami, preventDefault } from 'lib/util';
+
 import { QuantizeOptions } from './processor-meta';
-import * as style from '../../components/Options/style.scss';
 import Expander from '../../components/expander';
 import Select from '../../components/select';
 import Range from '../../components/range';
+
+import * as style from '../../components/Options/style.scss';
 
 const konamiPromise = konami();
 

--- a/src/codecs/imagequant/processor.ts
+++ b/src/codecs/imagequant/processor.ts
@@ -1,5 +1,6 @@
-import imagequant, { QuantizerModule } from '../../../codecs/imagequant/imagequant';
-import wasmUrl from '../../../codecs/imagequant/imagequant.wasm';
+import imagequant, { QuantizerModule } from '@codecs/imagequant/imagequant';
+import wasmUrl from '@codecs/imagequant/imagequant.wasm';
+
 import { QuantizeOptions } from './processor-meta';
 import { initEmscriptenModule } from '../util';
 

--- a/src/codecs/mozjpeg/encoder.ts
+++ b/src/codecs/mozjpeg/encoder.ts
@@ -1,5 +1,6 @@
-import mozjpeg_enc, { MozJPEGModule } from '../../../codecs/mozjpeg_enc/mozjpeg_enc';
-import wasmUrl from '../../../codecs/mozjpeg_enc/mozjpeg_enc.wasm';
+import mozjpeg_enc, { MozJPEGModule } from '@codecs/mozjpeg_enc/mozjpeg_enc';
+import wasmUrl from '@codecs/mozjpeg_enc/mozjpeg_enc.wasm';
+
 import { EncodeOptions } from './encoder-meta';
 import { initEmscriptenModule } from '../util';
 

--- a/src/codecs/mozjpeg/options.tsx
+++ b/src/codecs/mozjpeg/options.tsx
@@ -1,13 +1,16 @@
 import { h, Component } from 'preact';
-import { bind } from '../../lib/initial-util';
-import { inputFieldChecked, inputFieldValueAsNumber, preventDefault } from '../../lib/util';
+import linkState from 'linkstate';
+
+import { bind } from 'lib/initial-util';
+import { inputFieldChecked, inputFieldValueAsNumber, preventDefault } from 'lib/util';
+
 import { EncodeOptions, MozJpegColorSpace } from './encoder-meta';
-import * as style from '../../components/Options/style.scss';
 import Checkbox from '../../components/checkbox';
 import Expander from '../../components/expander';
 import Select from '../../components/select';
 import Range from '../../components/range';
-import linkState from 'linkstate';
+
+import * as style from '../../components/Options/style.scss';
 
 interface Props {
   options: EncodeOptions;

--- a/src/codecs/optipng/encoder.ts
+++ b/src/codecs/optipng/encoder.ts
@@ -1,5 +1,6 @@
-import optipng, { OptiPngModule } from '../../../codecs/optipng/optipng';
-import wasmUrl from '../../../codecs/optipng/optipng.wasm';
+import optipng, { OptiPngModule } from '@codecs/optipng/optipng';
+import wasmUrl from '@codecs/optipng/optipng.wasm';
+
 import { EncodeOptions } from './encoder-meta';
 import { initEmscriptenModule } from '../util';
 

--- a/src/codecs/optipng/options.tsx
+++ b/src/codecs/optipng/options.tsx
@@ -1,8 +1,11 @@
 import { h, Component } from 'preact';
-import { bind } from '../../lib/initial-util';
-import { inputFieldValueAsNumber, preventDefault } from '../../lib/util';
+
+import { bind } from 'lib/initial-util';
+import { inputFieldValueAsNumber, preventDefault } from 'lib/util';
+
 import { EncodeOptions } from './encoder-meta';
 import Range from '../../components/range';
+
 import * as style from '../../components/Options/style.scss';
 
 type Props = {

--- a/src/codecs/processor.ts
+++ b/src/codecs/processor.ts
@@ -1,6 +1,8 @@
 import { proxy } from 'comlink';
+
+import { canvasEncode, blobToArrayBuffer } from 'lib/util';
+
 import { QuantizeOptions } from './imagequant/processor-meta';
-import { canvasEncode, blobToArrayBuffer } from '../lib/util';
 import { EncodeOptions as MozJPEGEncoderOptions } from './mozjpeg/encoder-meta';
 import { EncodeOptions as OptiPNGEncoderOptions } from './optipng/encoder-meta';
 import { EncodeOptions as WebPEncoderOptions } from './webp/encoder-meta';

--- a/src/codecs/resize/options.tsx
+++ b/src/codecs/resize/options.tsx
@@ -1,9 +1,11 @@
 import { h, Component } from 'preact';
 import linkState from 'linkstate';
-import { bind, linkRef } from '../../lib/initial-util';
+
+import { bind, linkRef } from 'lib/initial-util';
 import {
   inputFieldValueAsNumber, inputFieldValue, preventDefault, inputFieldChecked,
-} from '../../lib/util';
+} from 'lib/util';
+
 import { ResizeOptions, isWorkerOptions } from './processor-meta';
 import * as style from '../../components/Options/style.scss';
 import Checkbox from '../../components/checkbox';

--- a/src/codecs/resize/processor-sync.ts
+++ b/src/codecs/resize/processor-sync.ts
@@ -1,4 +1,5 @@
-import { nativeResize, NativeResizeMethod, drawableToImageData } from '../../lib/util';
+import { nativeResize, NativeResizeMethod, drawableToImageData } from 'lib/util';
+
 import { BrowserResizeOptions, VectorResizeOptions } from './processor-meta';
 import { getContainOffsets } from './util';
 

--- a/src/codecs/resize/processor.ts
+++ b/src/codecs/resize/processor.ts
@@ -1,10 +1,11 @@
-import wasmUrl from '../../../codecs/resize/pkg/resize_bg.wasm';
-import '../../../codecs/resize/pkg/resize';
+import wasmUrl from '@codecs/resize/pkg/resize_bg.wasm';
+import '@codecs/resize/pkg/resize';
+
 import { WorkerResizeOptions } from './processor-meta';
 import { getContainOffsets } from './util';
 
 interface WasmBindgenExports {
-  resize: typeof import('../../../codecs/resize/pkg/resize').resize;
+  resize: typeof import('@codecs/resize/pkg/resize').resize;
 }
 
 type WasmBindgen = ((url: string) => Promise<void>) & WasmBindgenExports;

--- a/src/codecs/rotate/processor.ts
+++ b/src/codecs/rotate/processor.ts
@@ -1,4 +1,5 @@
-import wasmUrl from '../../../codecs/rotate/rotate.wasm';
+import wasmUrl from '@codecs/rotate/rotate.wasm';
+
 import { RotateOptions, RotateModuleInstance } from './processor-meta';
 
 // We are loading a 500B module here. Loading the code to feature-detect

--- a/src/codecs/webp/decoder.ts
+++ b/src/codecs/webp/decoder.ts
@@ -1,5 +1,6 @@
-import webp_dec, { WebPModule } from '../../../codecs/webp_dec/webp_dec';
-import wasmUrl from '../../../codecs/webp_dec/webp_dec.wasm';
+import webp_dec, { WebPModule } from '@codecs/webp_dec/webp_dec';
+import wasmUrl from '@codecs/webp_dec/webp_dec.wasm';
+
 import { initEmscriptenModule } from '../util';
 
 let emscriptenModule: Promise<WebPModule>;

--- a/src/codecs/webp/encoder.ts
+++ b/src/codecs/webp/encoder.ts
@@ -1,5 +1,6 @@
-import webp_enc, { WebPModule } from '../../../codecs/webp_enc/webp_enc';
-import wasmUrl from '../../../codecs/webp_enc/webp_enc.wasm';
+import webp_enc, { WebPModule } from '@codecs/webp_enc/webp_enc';
+import wasmUrl from '@codecs/webp_enc/webp_enc.wasm';
+
 import { EncodeOptions } from './encoder-meta';
 import { initEmscriptenModule } from '../util';
 

--- a/src/codecs/webp/options.tsx
+++ b/src/codecs/webp/options.tsx
@@ -1,13 +1,16 @@
 import { h, Component } from 'preact';
-import { bind } from '../../lib/initial-util';
-import { inputFieldCheckedAsNumber, inputFieldValueAsNumber, preventDefault } from '../../lib/util';
+import linkState from 'linkstate';
+
+import { bind } from 'lib/initial-util';
+import { inputFieldCheckedAsNumber, inputFieldValueAsNumber, preventDefault } from 'lib/util';
+
 import { EncodeOptions, WebPImageHint } from './encoder-meta';
-import * as style from '../../components/Options/style.scss';
 import Checkbox from '../../components/checkbox';
 import Expander from '../../components/expander';
 import Select from '../../components/select';
 import Range from '../../components/range';
-import linkState from 'linkstate';
+
+import * as style from '../../components/Options/style.scss';
 
 interface Props {
   options: EncodeOptions;

--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -1,13 +1,16 @@
 import { h, Component } from 'preact';
 
-import { bind, linkRef, Fileish } from '../../lib/initial-util';
-import * as style from './style.scss';
 import { FileDropEvent } from 'file-drop-element';
 import 'file-drop-element';
-import SnackBarElement, { SnackOptions } from '../../lib/SnackBar';
-import '../../lib/SnackBar';
+
+import { bind, linkRef, Fileish } from 'lib/initial-util';
+import SnackBarElement, { SnackOptions } from 'lib/SnackBar';
+import 'lib/SnackBar';
+
 import Intro from '../intro';
 import '../custom-els/LoadingSpinner';
+
+import * as style from './style.scss';
 
 const ROUTE_EDITOR = '/editor';
 

--- a/src/components/Options/index.tsx
+++ b/src/components/Options/index.tsx
@@ -1,29 +1,27 @@
 import { h, Component } from 'preact';
 
-import * as style from './style.scss';
-import { bind } from '../../lib/initial-util';
-import { cleanSet, cleanMerge } from '../../lib/clean-modify';
-import OptiPNGEncoderOptions from '../../codecs/optipng/options';
-import MozJpegEncoderOptions from '../../codecs/mozjpeg/options';
-import BrowserJPEGEncoderOptions from '../../codecs/browser-jpeg/options';
-import WebPEncoderOptions from '../../codecs/webp/options';
-import BrowserWebPEncoderOptions from '../../codecs/browser-webp/options';
+import { bind } from 'lib/initial-util';
+import { cleanSet, cleanMerge } from 'lib/clean-modify';
 
-import QuantizerOptionsComponent from '../../codecs/imagequant/options';
-import ResizeOptionsComponent from '../../codecs/resize/options';
-
-import * as identity from '../../codecs/identity/encoder-meta';
-import * as optiPNG from '../../codecs/optipng/encoder-meta';
-import * as mozJPEG from '../../codecs/mozjpeg/encoder-meta';
-import * as webP from '../../codecs/webp/encoder-meta';
-import * as browserPNG from '../../codecs/browser-png/encoder-meta';
-import * as browserJPEG from '../../codecs/browser-jpeg/encoder-meta';
-import * as browserWebP from '../../codecs/browser-webp/encoder-meta';
-import * as browserGIF from '../../codecs/browser-gif/encoder-meta';
-import * as browserTIFF from '../../codecs/browser-tiff/encoder-meta';
-import * as browserJP2 from '../../codecs/browser-jp2/encoder-meta';
-import * as browserBMP from '../../codecs/browser-bmp/encoder-meta';
-import * as browserPDF from '../../codecs/browser-pdf/encoder-meta';
+import OptiPNGEncoderOptions from 'codecs/optipng/options';
+import MozJpegEncoderOptions from 'codecs/mozjpeg/options';
+import BrowserJPEGEncoderOptions from 'codecs/browser-jpeg/options';
+import WebPEncoderOptions from 'codecs/webp/options';
+import BrowserWebPEncoderOptions from 'codecs/browser-webp/options';
+import QuantizerOptionsComponent from 'codecs/imagequant/options';
+import ResizeOptionsComponent from 'codecs/resize/options';
+import * as identity from 'codecs/identity/encoder-meta';
+import * as optiPNG from 'codecs/optipng/encoder-meta';
+import * as mozJPEG from 'codecs/mozjpeg/encoder-meta';
+import * as webP from 'codecs/webp/encoder-meta';
+import * as browserPNG from 'codecs/browser-png/encoder-meta';
+import * as browserJPEG from 'codecs/browser-jpeg/encoder-meta';
+import * as browserWebP from 'codecs/browser-webp/encoder-meta';
+import * as browserGIF from 'codecs/browser-gif/encoder-meta';
+import * as browserTIFF from 'codecs/browser-tiff/encoder-meta';
+import * as browserJP2 from 'codecs/browser-jp2/encoder-meta';
+import * as browserBMP from 'codecs/browser-bmp/encoder-meta';
+import * as browserPDF from 'codecs/browser-pdf/encoder-meta';
 import {
   EncoderState,
   EncoderType,
@@ -31,14 +29,17 @@ import {
   encoders,
   encodersSupported,
   EncoderSupportMap,
-} from '../../codecs/encoders';
-import { QuantizeOptions } from '../../codecs/imagequant/processor-meta';
-import { ResizeOptions } from '../../codecs/resize/processor-meta';
-import { PreprocessorState } from '../../codecs/preprocessors';
+} from 'codecs/encoders';
+import { QuantizeOptions } from 'codecs/imagequant/processor-meta';
+import { ResizeOptions } from 'codecs/resize/processor-meta';
+import { PreprocessorState } from 'codecs/preprocessors';
+
 import { SourceImage } from '../compress';
 import Checkbox from '../checkbox';
 import Expander from '../expander';
 import Select from '../select';
+
+import * as style from './style.scss';
 
 const encoderOptionsComponentMap: {
   [x: string]: (new (...args: any[]) => Component<any, any>) | undefined;
@@ -178,7 +179,7 @@ export default class Options extends Component<Props, State> {
           {encoderSupportMap ?
             <Select value={encoderState.type} onChange={this.onEncoderTypeChange} large>
               {encoders.filter(encoder => encoderSupportMap[encoder.type]).map(encoder => (
-                <option value={encoder.type}>{encoder.label}</option>
+                <option key={encoder.type} value={encoder.type}>{encoder.label}</option>
               ))}
             </Select>
             :

--- a/src/components/Output/index.tsx
+++ b/src/components/Output/index.tsx
@@ -1,10 +1,12 @@
 import { h, Component } from 'preact';
+
 import PinchZoom, { ScaleToOpts } from './custom-els/PinchZoom';
 import './custom-els/PinchZoom';
 import './custom-els/TwoUp';
-import * as style from './style.scss';
-import { bind, linkRef } from '../../lib/initial-util';
-import { shallowEqual, drawDataToCanvas } from '../../lib/util';
+import { SourceImage } from '../compress';
+
+import { bind, linkRef } from 'lib/initial-util';
+import { shallowEqual, drawDataToCanvas } from 'lib/util';
 import {
     ToggleBackgroundIcon,
     AddIcon,
@@ -12,11 +14,13 @@ import {
     BackIcon,
     ToggleBackgroundActiveIcon,
     RotateIcon,
-} from '../../lib/icons';
+} from 'lib/icons';
+import { cleanSet } from 'lib/clean-modify';
+
+import { InputProcessorState } from 'codecs/input-processors';
+
 import { twoUpHandle } from './custom-els/TwoUp/styles.css';
-import { InputProcessorState } from '../../codecs/input-processors';
-import { cleanSet } from '../../lib/clean-modify';
-import { SourceImage } from '../compress';
+import * as style from './style.scss';
 
 interface Props {
   source?: SourceImage;

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -1,6 +1,8 @@
 import { h, Component } from 'preact';
+
+import { UncheckedIcon, CheckedIcon } from 'lib/icons';
+
 import * as style from './style.scss';
-import { UncheckedIcon, CheckedIcon } from '../../lib/icons';
 
 interface Props extends JSX.HTMLAttributes {}
 interface State {}

--- a/src/components/compress/custom-els/MultiPanel/index.ts
+++ b/src/components/compress/custom-els/MultiPanel/index.ts
@@ -1,5 +1,6 @@
+import { transitionHeight } from 'lib/util';
+
 import * as style from './styles.css';
-import { transitionHeight } from '../../../../lib/util';
 
 interface CloseAllOptions {
   exceptFirst?: boolean;

--- a/src/components/compress/index.tsx
+++ b/src/components/compress/index.tsx
@@ -1,36 +1,40 @@
 import { h, Component } from 'preact';
 
-import { bind, Fileish } from '../../lib/initial-util';
-import { blobToImg, drawableToImageData, blobToText } from '../../lib/util';
-import * as style from './style.scss';
-import Output from '../Output';
-import Options from '../Options';
-import ResultCache from './result-cache';
-import * as identity from '../../codecs/identity/encoder-meta';
-import * as optiPNG from '../../codecs/optipng/encoder-meta';
-import * as mozJPEG from '../../codecs/mozjpeg/encoder-meta';
-import * as webP from '../../codecs/webp/encoder-meta';
-import * as browserPNG from '../../codecs/browser-png/encoder-meta';
-import * as browserJPEG from '../../codecs/browser-jpeg/encoder-meta';
-import * as browserWebP from '../../codecs/browser-webp/encoder-meta';
-import * as browserGIF from '../../codecs/browser-gif/encoder-meta';
-import * as browserTIFF from '../../codecs/browser-tiff/encoder-meta';
-import * as browserJP2 from '../../codecs/browser-jp2/encoder-meta';
-import * as browserBMP from '../../codecs/browser-bmp/encoder-meta';
-import * as browserPDF from '../../codecs/browser-pdf/encoder-meta';
-import { EncoderState, EncoderType, EncoderOptions, encoderMap } from '../../codecs/encoders';
-import { PreprocessorState, defaultPreprocessorState } from '../../codecs/preprocessors';
-import { decodeImage } from '../../codecs/decoders';
-import { cleanMerge, cleanSet } from '../../lib/clean-modify';
-import Processor from '../../codecs/processor';
+import { bind, Fileish } from 'lib/initial-util';
+import { blobToImg, drawableToImageData, blobToText } from 'lib/util';
+import { cleanMerge, cleanSet } from 'lib/clean-modify';
+import { ExpandIcon, CopyAcrossIconProps } from 'lib/icons';
+import SnackBarElement from 'lib/SnackBar';
+
+import * as identity from 'codecs/identity/encoder-meta';
+import * as optiPNG from 'codecs/optipng/encoder-meta';
+import * as mozJPEG from 'codecs/mozjpeg/encoder-meta';
+import * as webP from 'codecs/webp/encoder-meta';
+import * as browserPNG from 'codecs/browser-png/encoder-meta';
+import * as browserJPEG from 'codecs/browser-jpeg/encoder-meta';
+import * as browserWebP from 'codecs/browser-webp/encoder-meta';
+import * as browserGIF from 'codecs/browser-gif/encoder-meta';
+import * as browserTIFF from 'codecs/browser-tiff/encoder-meta';
+import * as browserJP2 from 'codecs/browser-jp2/encoder-meta';
+import * as browserBMP from 'codecs/browser-bmp/encoder-meta';
+import * as browserPDF from 'codecs/browser-pdf/encoder-meta';
+import { EncoderState, EncoderType, EncoderOptions, encoderMap } from 'codecs/encoders';
+import { PreprocessorState, defaultPreprocessorState } from 'codecs/preprocessors';
+import { decodeImage } from 'codecs/decoders';
+import Processor from 'codecs/processor';
 import {
   BrowserResizeOptions, isWorkerOptions as isWorkerResizeOptions,
-} from '../../codecs/resize/processor-meta';
-import './custom-els/MultiPanel';
+} from 'codecs/resize/processor-meta';
+import { InputProcessorState, defaultInputProcessorState } from 'codecs/input-processors';
+
+import Output from '../Output';
+import Options from '../Options';
 import Results from '../results';
-import { ExpandIcon, CopyAcrossIconProps } from '../../lib/icons';
-import SnackBarElement from '../../lib/SnackBar';
-import { InputProcessorState, defaultInputProcessorState } from '../../codecs/input-processors';
+import ResultCache from './result-cache';
+
+import './custom-els/MultiPanel';
+
+import * as style from './style.scss';
 
 export interface SourceImage {
   file: File | Fileish;
@@ -244,7 +248,7 @@ export default class Compress extends Component<Props, State> {
     this.widthQuery.addListener(this.onMobileWidthChange);
     this.updateFile(props.file);
 
-    import('../../lib/offliner').then(({ mainAppLoaded }) => mainAppLoaded());
+    import('lib/offliner').then(({ mainAppLoaded }) => mainAppLoaded());
   }
 
   @bind
@@ -568,6 +572,7 @@ export default class Compress extends Component<Props, State> {
 
     const options = sides.map((side, index) => (
       <Options
+        key={index}
         source={source}
         mobileView={mobileView}
         preprocessorState={side.latestSettings.preprocessorState}
@@ -583,6 +588,7 @@ export default class Compress extends Component<Props, State> {
 
     const results = sides.map((side, index) => (
       <Results
+        key={index}
         downloadUrl={side.downloadUrl}
         imageFile={side.file}
         source={source}

--- a/src/components/compress/result-cache.ts
+++ b/src/components/compress/result-cache.ts
@@ -1,9 +1,9 @@
-import { EncoderState } from '../../codecs/encoders';
-import { Fileish } from '../../lib/initial-util';
-import { shallowEqual } from '../../lib/util';
-import { PreprocessorState } from '../../codecs/preprocessors';
+import { EncoderState } from 'codecs/encoders';
+import { PreprocessorState } from 'codecs/preprocessors';
+import * as identity from 'codecs/identity/encoder-meta';
 
-import * as identity from '../../codecs/identity/encoder-meta';
+import { Fileish } from 'lib/initial-util';
+import { shallowEqual } from 'lib/util';
 
 interface CacheResult {
   preprocessed: ImageData;

--- a/src/components/expander/index.tsx
+++ b/src/components/expander/index.tsx
@@ -1,6 +1,8 @@
 import { h, Component, ComponentChild, ComponentChildren } from 'preact';
+
+import { transitionHeight } from 'lib/util';
+
 import * as style from './style.scss';
-import { transitionHeight } from '../../lib/util';
 
 interface Props {
   children: ComponentChildren;

--- a/src/components/intro/index.tsx
+++ b/src/components/intro/index.tsx
@@ -1,8 +1,9 @@
 import { h, Component } from 'preact';
 
-import { bind, linkRef, Fileish } from '../../lib/initial-util';
-import '../custom-els/LoadingSpinner';
+import { bind, linkRef, Fileish } from 'lib/initial-util';
+import SnackBarElement from 'lib/SnackBar';
 
+import '../custom-els/LoadingSpinner';
 import logo from './imgs/logo.svg';
 import largePhoto from './imgs/demos/demo-large-photo.jpg';
 import artwork from './imgs/demos/demo-artwork.jpg';
@@ -11,8 +12,8 @@ import largePhotoIcon from './imgs/demos/icon-demo-large-photo.jpg';
 import artworkIcon from './imgs/demos/icon-demo-artwork.jpg';
 import deviceScreenIcon from './imgs/demos/icon-demo-device-screen.jpg';
 import logoIcon from './imgs/demos/icon-demo-logo.png';
+
 import * as style from './style.scss';
-import SnackBarElement from '../../lib/SnackBar';
 
 const demos = [
   {

--- a/src/components/range/index.tsx
+++ b/src/components/range/index.tsx
@@ -1,8 +1,11 @@
 import { h, Component } from 'preact';
-import * as style from './style.scss';
+
+import { linkRef, bind } from 'lib/initial-util';
+
 import RangeInputElement from '../../custom-els/RangeInput';
 import '../../custom-els/RangeInput';
-import { linkRef, bind } from '../../lib/initial-util';
+
+import * as style from './style.scss';
 
 interface Props extends JSX.HTMLAttributes {}
 interface State {}

--- a/src/components/results/index.tsx
+++ b/src/components/results/index.tsx
@@ -1,11 +1,13 @@
 import { h, Component, ComponentChildren, ComponentChild } from 'preact';
 
-import * as style from './style.scss';
+import { DownloadIcon, CopyAcrossIcon, CopyAcrossIconProps } from 'lib/icons';
+import { Fileish, bind } from 'lib/initial-util';
+
 import FileSize from './FileSize';
-import { DownloadIcon, CopyAcrossIcon, CopyAcrossIconProps } from '../../lib/icons';
 import '../custom-els/LoadingSpinner';
 import { SourceImage } from '../compress';
-import { Fileish, bind } from '../../lib/initial-util';
+
+import * as style from './style.scss';
 
 interface Props {
   loading: boolean;

--- a/src/custom-els/RangeInput/index.ts
+++ b/src/custom-els/RangeInput/index.ts
@@ -1,5 +1,7 @@
 import PointerTracker from 'pointer-tracker';
-import { bind } from '../../lib/initial-util';
+
+import { bind } from 'lib/initial-util';
+
 import * as style from './styles.css';
 
 const RETARGETED_EVENTS = ['focus', 'blur'];

--- a/src/init-app.tsx
+++ b/src/init-app.tsx
@@ -1,5 +1,5 @@
 import { h, render } from 'preact';
-import './lib/fix-pmc';
+import 'lib/fix-pmc';
 import './style';
 import App from './components/App';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,13 @@
     "jsx": "react",
     "jsxFactory": "h",
     "allowJs": false,
-    "baseUrl": "."
-  },
+    "baseUrl": ".",
+    "paths": {
+      "codecs/*": ["src/codecs/*"],
+      "lib/*": ["src/lib/*"],
+      "@codecs/*": ["codecs/*"]
+    }
+	},
   "exclude": [
     "src/sw/**/*",
     "src/codecs/processor-worker/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
       "lib/*": ["src/lib/*"],
       "@codecs/*": ["codecs/*"]
     }
-	},
+  },
   "exclude": [
     "src/sw/**/*",
     "src/codecs/processor-worker/**/*"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,10 @@ module.exports = async function (_, env) {
     resolve: {
       extensions: ['.ts', '.tsx', '.mjs', '.js', '.scss', '.css'],
       alias: {
-        style: path.join(__dirname, 'src/style')
+        style: path.join(__dirname, 'src/style'),
+        codecs: path.join(__dirname, 'src/codecs'),
+        lib: path.join(__dirname, 'src/lib'),
+        '@codecs': path.join(__dirname, 'codecs')
       }
     },
     resolveLoader: {


### PR DESCRIPTION
Hey, guys, thanks for the great app! This PR adds path aliases for `codecs` (alias `@codecs`), `src/codecs` (alias `codecs`) and `src/lib` (alias `lib`) so that we don't have to write these dot-dot-slash chains anymore 😃 I also took the liberty to slightly reorder some import declarations and add spaces between import groups so that in each file imports follow the same order and it's easier to read the code. Also, there're a couple of `tslint` fixes related to missing `key` props.