### PR TITLE
Display filename on desktop.

### DIFF
--- a/src/components/Output/index.tsx
+++ b/src/components/Output/index.tsx
@@ -256,6 +256,7 @@ export default class Output extends Component<Props, State> {
     const rightDraw = this.rightDrawable();
     // To keep position stable, the output is put in a square using the longest dimension.
     const originalImage = source && source.processed;
+    const fileName = source && source.file.name;
 
     return (
       <div class={`${style.output} ${altBackground ? style.altBackground : ''}`}>
@@ -308,6 +309,12 @@ export default class Output extends Component<Props, State> {
             <BackIcon />
           </button>
         </div>
+
+        {
+          fileName && <div class={style.filename}>
+            <h3 class={style.filenameText}>{fileName}</h3>
+          </div>
+        }
 
         <div class={style.controls}>
           <div class={style.zoomControls}>

--- a/src/components/Output/style.scss
+++ b/src/components/Output/style.scss
@@ -156,6 +156,32 @@
   padding: 9px;
 }
 
+.filename {
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 0;
+  max-width: 300px;
+
+  @media (max-width: 860px) {
+    display: none;  // hide filename when controls are collapsed
+  }
+}
+
+.filename-text {
+  color: #fff;
+  background: rgba(0, 0, 0, 0.7);
+  margin: 0;
+  padding: 10px;
+  font-weight: normal;
+  font-size: 1.4rem;
+  border-bottom: 1px solid #000;
+
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .buttons-no-wrap {
   display: flex;
   pointer-events: none;


### PR DESCRIPTION
This is an attempt to resolve: https://github.com/GoogleChromeLabs/squoosh/issues/244
The changes add filename into UI for desktop.

1. Display filename in the top right corner:
<img width="1440" alt="regular_name_usecase" src="https://user-images.githubusercontent.com/9870032/59615667-958a4980-912b-11e9-976c-7bf81fc91203.png">

2. If the filename is longer than 300px it's truncated with ellipses:
<img width="1440" alt="long_name_usecase" src="https://user-images.githubusercontent.com/9870032/59615771-cbc7c900-912b-11e9-9712-016cbb1bb7b0.png">

3. If control buttons collapsed (screen_width < 860px) filename is hidden to prevent overlapping:
<img width="862" alt="controls_collapsed_usecase" src="https://user-images.githubusercontent.com/9870032/59615847-f285ff80-912b-11e9-95cc-68ca7ef30cbe.png">

@jakearchibald @surma @kosamari  please review =)

P.S. I'm not much of a designer, so I didn't figure out where to put filename on mobiles.