### PR TITLE
Use document.title and ⏳ emoji to indicate when work is being done 

### DIFF
--- a/src/components/compress/index.tsx
+++ b/src/components/compress/index.tsx
@@ -295,9 +295,13 @@ export default class Compress extends Component<Props, State> {
   private updateLoadingIndicator(isLoading: boolean = false): void {
     // Update the title if the editor loading state changes
     if (isLoading) {
-      document.title = loadingIndicator + document.title;
-    } else if (document.title.startsWith(loadingIndicator)){
-      document.title = document.title.slice(loadingIndicator.length);
+      if (!document.title.startsWith(loadingIndicator)) {
+        document.title = loadingIndicator + document.title;
+      }
+    } else {
+      if (document.title.startsWith(loadingIndicator)) {
+        document.title = document.title.slice(loadingIndicator.length);
+      }
     }
   }
 
@@ -315,7 +319,8 @@ export default class Compress extends Component<Props, State> {
     const { loading, source, sides } = this.state;
 
     const isLoading = loading || sides[0].loading || sides[1].loading;
-    const loadingStateChanged = isLoading !== (prevState.loading || prevState.sides[0].loading || prevState.sides[1].loading);
+    const loadingStateChanged = isLoading !==
+      prevState.loading || prevState.sides[0].loading || prevState.sides[1].loading;
 
     if (loadingStateChanged) {
       this.updateLoadingIndicator(isLoading);

--- a/src/components/compress/index.tsx
+++ b/src/components/compress/index.tsx
@@ -215,6 +215,9 @@ const buttonPositions =
 
 const originalDocumentTitle = document.title;
 
+// Prefixed to the window title if app is loading something
+const loadingIndicator = '⏳ ';
+
 export default class Compress extends Component<Props, State> {
   widthQuery = window.matchMedia('(max-width: 599px)');
 
@@ -289,6 +292,15 @@ export default class Compress extends Component<Props, State> {
     document.title = filename ? `${filename} - ${originalDocumentTitle}` : originalDocumentTitle;
   }
 
+  private updateLoadingIndicator(isLoading: boolean = false): void {
+    // Update the title if the editor loading state changes
+    if (isLoading) {
+      document.title = loadingIndicator + document.title;
+    } else if (document.title.startsWith(loadingIndicator)){
+      document.title = document.title.slice(loadingIndicator.length);
+    }
+  }
+
   componentWillReceiveProps(nextProps: Props): void {
     if (nextProps.file !== this.props.file) {
       this.updateFile(nextProps.file);
@@ -300,7 +312,14 @@ export default class Compress extends Component<Props, State> {
   }
 
   componentDidUpdate(prevProps: Props, prevState: State): void {
-    const { source, sides } = this.state;
+    const { loading, source, sides } = this.state;
+
+    const isLoading = loading || sides[0].loading || sides[1].loading;
+    const loadingStateChanged = isLoading !== (prevState.loading || prevState.sides[0].loading || prevState.sides[1].loading);
+
+    if (loadingStateChanged) {
+      this.updateLoadingIndicator(isLoading);
+    }
 
     const sourceDataChanged =
       // Has the source object become set/unset?


### PR DESCRIPTION
Solution for #644 

Listens to changes in the loading status within the `Compress` component. If a change in loading status is detected and something is loading, append a ⏳ emoji to the `document.title`

*GIFs*

Classic example w/ the famous Lenna  test image. See that the `document.title` updates as the image compresses 
![classic_lenna_example](https://user-images.githubusercontent.com/4969041/63001129-be774400-be27-11e9-9daa-7dea389d6cba.gif)

Another example w/ the provided `photo.jpg`. Notice that at a point, both sides are loading/doing work (apologies, had to resize GIF to meet Github's size requirements and Squoosh doesn't support animations 😉) 

![another_photo_example](https://user-images.githubusercontent.com/4969041/63001253-0dbd7480-be28-11e9-807f-9fddec26cee7.gif)

---

Starting  to get into open source and thought this was a neat issue. Also think it would be neat to explore using the `document.title` to output an error emoji in the title like `🚨` 