### PR TITLE
Set loading state to false on error

### DIFF
--- a/src/components/compress/index.tsx
+++ b/src/components/compress/index.tsx
@@ -549,6 +549,8 @@ export default class Compress extends Component<Props, State> {
       } catch (err) {
         if (err.name === 'AbortError') return;
         this.props.showSnack(`Processing error (type=${settings.encoderState.type}): ${err}`);
+        sides = cleanMerge(this.state.sides, index, { loading: false });
+        this.setState({ sides });
         throw err;
       }
     }


### PR DESCRIPTION
I noticed that loading state is only set to false after successful image processing, and in case of error the spinner never stops spinning.

Steps to reproduce (might not work for everybody):
* Load the "device screen" sample photo
* Click resize
* Click up arrow to increase width

Noticed on Chrome 79 and Firefox 72 on Linux