### PR TITLE
Use closure in optipng build, which shrinks the JS to less than half

### DIFF
--- a/codecs/optipng/build.sh
+++ b/codecs/optipng/build.sh
@@ -27,6 +27,7 @@ echo "============================================="
   emcc \
     --bind \
     ${OPTIMIZE} \
+    --closure 1 \
     -s ALLOW_MEMORY_GROWTH=1 -s MODULARIZE=1 -s 'EXPORT_NAME="optipng"' \
     -o "optipng.js" \
     --std=c++11 \


### PR DESCRIPTION
Specifically the size shrinks from 108K to 46K :smiley: 

I'm hopeful this just works, as the project already uses MODULARIZE (so nothing can access internals from outside, which is dangerous with closure). Is there a test suite I should run locally? Or will CI here run tests?