### PR TITLE
Fixup clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,2 @@
 BasedOnStyle: Chromium
-ColumnLimit: 120
+ColumnLimit: 100


### PR DESCRIPTION
I've actually comitted files formatted with column limit of 100, but forgot to include updated .clang-format 🤦🏻‍♂️