### PR TITLE
Fix typo for "spatial"

### DIFF
--- a/src/codecs/webp/options.tsx
+++ b/src/codecs/webp/options.tsx
@@ -270,7 +270,7 @@ export default class WebPEncoderOptions extends Component<Props, State> {
                   value={options.sns_strength}
                   onInput={this.onChange}
                 >
-                  Spacial noise shaping:
+                  Spatial noise shaping:
                 </Range>
               </div>
               <label class={style.optionTextFirst}>


### PR DESCRIPTION
As shown in today's Web.dev/live/ chat, updating a minor copy typo in the interface.