### PR TITLE
Update privacy link

### DIFF
--- a/src/components/intro/index.tsx
+++ b/src/components/intro/index.tsx
@@ -204,7 +204,7 @@ export default class Intro extends Component<Props, State> {
           <li><a href="https://github.com/GoogleChromeLabs/squoosh/">View the code</a></li>
           <li><a href="https://github.com/GoogleChromeLabs/squoosh/issues">Report a bug</a></li>
           <li>
-            <a href="https://github.com/GoogleChromeLabs/squoosh/blob/master/README.md#privacy">
+            <a href="https://github.com/GoogleChromeLabs/squoosh/blob/dev/README.md#privacy">
               Privacy
             </a>
           </li>


### PR DESCRIPTION
Hi, thanks for this awesome app!

The privacy link on the front page is currently broken, as the default branch has been renamed. This PR fixes that.

I also believe `branch` should be updated here, but i'm not 100% sure:
https://github.com/GoogleChromeLabs/squoosh/blob/d94835402fe33b449d8c5bff09334e2f3e6ac175/sizereport.config.js#L3-L6
