### PR TITLE
Updates to analytics for PWAs

### DIFF
--- a/src/components/intro/index.tsx
+++ b/src/components/intro/index.tsx
@@ -41,7 +41,7 @@ const demos = [
   },
 ];
 
-const installButtonSource = 'introInstallButton';
+const installButtonSource = 'introInstallButton-Purple';
 
 interface Props {
   onFile: (file: File | Fileish) => void;
@@ -113,7 +113,12 @@ export default class Intro extends Component<Props, State> {
     this.setState({ beforeInstallEvent: event });
 
     // Log the event.
-    ga('send', 'event', 'pwa-install', 'available');
+    const gaEventInfo = {
+      eventCategory: 'pwa-install',
+      eventAction: 'shown',
+      nonInteraction: true,
+    };
+    ga('send', 'event', gaEventInfo);
   }
 
   @bind
@@ -130,7 +135,14 @@ export default class Intro extends Component<Props, State> {
 
     // Wait for the user to accept or dismiss the install prompt
     const { outcome } = await beforeInstallEvent.userChoice;
-    ga('send', 'event', 'pwa-install', installButtonSource, outcome);
+    // Send the analytics data
+    const gaEventInfo = {
+      eventCategory: 'pwa-install',
+      eventAction: 'custom-install',
+      eventLabel: installButtonSource,
+      eventValue: outcome === 'accepted' ? 1 : 0,
+    };
+    ga('send', 'event', gaEventInfo);
 
     // If the prompt was dismissed, we aren't going to install via the button.
     if (outcome === 'dismissed') {

--- a/src/components/intro/index.tsx
+++ b/src/components/intro/index.tsx
@@ -115,7 +115,7 @@ export default class Intro extends Component<Props, State> {
     // Log the event.
     const gaEventInfo = {
       eventCategory: 'pwa-install',
-      eventAction: 'shown',
+      eventAction: 'promo-shown',
       nonInteraction: true,
     };
     ga('send', 'event', gaEventInfo);
@@ -138,7 +138,7 @@ export default class Intro extends Component<Props, State> {
     // Send the analytics data
     const gaEventInfo = {
       eventCategory: 'pwa-install',
-      eventAction: 'custom-install',
+      eventAction: 'promo-clicked',
       eventLabel: installButtonSource,
       eventValue: outcome === 'accepted' ? 1 : 0,
     };

--- a/src/components/intro/style.scss
+++ b/src/components/intro/style.scss
@@ -175,7 +175,7 @@
 
   &:hover,
   &:focus {
-    background: #f5f5f5;
+    background: #504488;
   }
 
   background: #5D509E;

--- a/src/components/intro/style.scss
+++ b/src/components/intro/style.scss
@@ -178,8 +178,9 @@
     background: #f5f5f5;
   }
 
-  background: #fff;
+  background: #5D509E;
   border: 1px solid #e8e8e8;
+  color: #fff;
   padding: 14px;
   font-size: 1.3rem;
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Squoosh",
   "short_name": "Squoosh",
-  "start_url": "/",
+  "start_url": "/?utm_medium=PWA&utm_source=launcher",
   "display": "standalone",
   "orientation": "any",
   "background_color": "#fff",
@@ -20,7 +20,7 @@
     }
   ],
   "share_target": {
-    "action": "/?share-target",
+    "action": "/?utm_medium=PWA&utm_source=launcher&share-target",
     "method": "POST",
     "enctype": "multipart/form-data",
     "params": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,7 +20,7 @@
     }
   ],
   "share_target": {
-    "action": "/?utm_medium=PWA&utm_source=launcher&share-target",
+    "action": "/?utm_medium=PWA&utm_source=share-target&share-target",
     "method": "POST",
     "enctype": "multipart/form-data",
     "params": {


### PR DESCRIPTION
This PR updates the behaviour in #764 and #765.

* Adds query string to the manifest `start_url` to track launches from the PWA 
  (`?utm_medium=PWA&utm_source=launcher`), ideally this will allow us to remove the dimension tracking we're 
  currently using.
* Changes the install button to the same color as the purple text to see if it has a higher CTR, hover color is the 
  same, but darkens the color by lowering the lightness value.
* Adds [`nonInteraction`](https://developers.google.com/analytics/devguides/collection/analyticsjs/events#non-interaction_events) 
  parameter to the `beforeinstallprompt` event analytics logging, since it's not user initiated.
* Standardizes the `action` and `label` names for events fired on install available, and when clicked. 
* Uses an event `value` instead of a label to track if the install was accepted from the install prompt.

These changes will help validate our best practices for analytics in PWAs.