### PR TITLE
Add Windows to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 cache: npm
 script: npm run build
 after_success: npm run sizereport
+os:
+  - linux
+  - windows


### PR DESCRIPTION
This will help to catch somewhat frequent Windows-specific issues in the future (latest example: #774).

Note that Windows on Travis tends to be quite a bit slower than Linux counterpart, but I believe it's worth it.