### PR TITLE
Fix #346 Add keyboard shortcuts for moving the split view separator

### DIFF
--- a/src/client/lazy-app/Compress/Output/custom-els/TwoUp/index.ts
+++ b/src/client/lazy-app/Compress/Output/custom-els/TwoUp/index.ts
@@ -68,6 +68,8 @@ export default class TwoUp extends HTMLElement {
         );
       },
     });
+
+    window.addEventListener('keydown', event => this._onKeyDown(event));
   }
 
   connectedCallback() {
@@ -91,6 +93,29 @@ export default class TwoUp extends HTMLElement {
   attributeChangedCallback(name: string) {
     if (name === orientationAttr) {
       this._resetPosition();
+    }
+  }
+
+  // KeyDown event handler
+  private _onKeyDown(event: KeyboardEvent) {
+    if (event.code === 'Digit1' || event.code === 'Numpad1') {
+      this._position = 0;
+      this._relativePosition = 0;
+      this._setPosition();
+    } else if (event.code === 'Digit2' || event.code === 'Numpad2') {
+      const dimensionAxis = this.orientation === 'vertical' ? 'height' : 'width';
+      const bounds = this.getBoundingClientRect();
+
+      this._position = bounds[dimensionAxis] / 2;
+      this._relativePosition = (this._position / bounds[dimensionAxis]) / 2;
+      this._setPosition();
+    } else if (event.code === 'Digit3' || event.code === 'Numpad3') {
+      const dimensionAxis = this.orientation === 'vertical' ? 'height' : 'width';
+      const bounds = this.getBoundingClientRect();
+
+      this._position = bounds[dimensionAxis];
+      this._relativePosition = this._position / bounds[dimensionAxis];
+      this._setPosition();
     }
   }
 


### PR DESCRIPTION
Fix #346.

I used the number keys 1, 2, and 3.

I would have used the arrow keys. Seems natural that pressing left and right would move the separator to the left and right, and pressing the middle up and down buttons moves it to the center. But the arrow keys are already in use for navigating the interface, so I had to come up with something else.

I also made an overlay/modal with some info about the shortcuts so that they are discoverable. I would have used the url router and a separate page for this info, but I couldn't find any router :sweat_smile:

This is my first time writing any preact or react code at all, so I'm not sure at all how idiomatically I've done things. Feel free to make any suggestions.