### PR TITLE
Promisify emscripten modules & fix webp examples

### DIFF
--- a/codecs/avif/dec/avif_dec.d.ts
+++ b/codecs/avif/dec/avif_dec.d.ts
@@ -2,5 +2,5 @@ interface AVIFModule extends EmscriptenWasm.Module {
   decode(data: BufferSource): ImageData | null;
 }
 
-export default function(opts: EmscriptenWasm.ModuleOpts): AVIFModule;
+export default function(opts: EmscriptenWasm.ModuleOpts): Promise<AVIFModule>;
 

--- a/codecs/avif/enc/avif_enc.d.ts
+++ b/codecs/avif/enc/avif_enc.d.ts
@@ -4,4 +4,4 @@ interface AVIFModule extends EmscriptenWasm.Module {
   encode(data: BufferSource, width: number, height: number, options: EncodeOptions): Uint8Array | null;
 }
 
-export default function(opts: EmscriptenWasm.ModuleOpts): AVIFModule;
+export default function(opts: EmscriptenWasm.ModuleOpts): Promise<AVIFModule>;

--- a/codecs/imagequant/imagequant.d.ts
+++ b/codecs/imagequant/imagequant.d.ts
@@ -3,4 +3,4 @@ interface QuantizerModule extends EmscriptenWasm.Module {
   zx_quantize(data: BufferSource, width: number, height: number, dither: number): Uint8ClampedArray;
 }
 
-export default function(opts: EmscriptenWasm.ModuleOpts): QuantizerModule;
+export default function(opts: EmscriptenWasm.ModuleOpts): Promise<QuantizerModule>;

--- a/codecs/mozjpeg_enc/mozjpeg_enc.d.ts
+++ b/codecs/mozjpeg_enc/mozjpeg_enc.d.ts
@@ -4,4 +4,4 @@ interface MozJPEGModule extends EmscriptenWasm.Module {
   encode(data: BufferSource, width: number, height: number, options: EncodeOptions): Uint8Array;
 }
 
-export default function(opts: EmscriptenWasm.ModuleOpts): MozJPEGModule;
+export default function(opts: EmscriptenWasm.ModuleOpts): Promise<MozJPEGModule>;

--- a/codecs/webp/dec/example.html
+++ b/codecs/webp/dec/example.html
@@ -6,16 +6,15 @@
     return await resp.arrayBuffer();
   }
 
-  (async _ => {
-    const Module = await webp_dec();
-    console.log('Version:', Module.version().toString(16));
+  webp_dec().then(async module => {
+    console.log('Version:', module.version().toString(16));
     const image = await loadFile('../../example.webp');
-    const imageData = Module.decode(image);
+    const imageData = module.decode(image);
     const canvas = document.createElement('canvas');
     canvas.width = imageData.width;
     canvas.height = imageData.height;
     document.body.appendChild(canvas);
     const ctx = canvas.getContext('2d');
     ctx.putImageData(imageData, 0, 0);
-  })();
+  });
 </script>

--- a/codecs/webp/dec/example.html
+++ b/codecs/webp/dec/example.html
@@ -1,22 +1,21 @@
 <!doctype html>
 <script src='webp_dec.js'></script>
 <script>
-  const Module = webp_dec();
-
   async function loadFile(src) {
     const resp = await fetch(src);
     return await resp.arrayBuffer();
   }
 
-  Module.onRuntimeInitialized = async _ => {
+  (async _ => {
+    const Module = await webp_dec();
     console.log('Version:', Module.version().toString(16));
     const image = await loadFile('../../example.webp');
     const imageData = Module.decode(image);
     const canvas = document.createElement('canvas');
-    canvas.width = result.width;
-    canvas.height = result.height;
+    canvas.width = imageData.width;
+    canvas.height = imageData.height;
     document.body.appendChild(canvas);
     const ctx = canvas.getContext('2d');
     ctx.putImageData(imageData, 0, 0);
-  };
+  })();
 </script>

--- a/codecs/webp/dec/webp_dec.d.ts
+++ b/codecs/webp/dec/webp_dec.d.ts
@@ -2,4 +2,4 @@ interface WebPModule extends EmscriptenWasm.Module {
   decode(data: BufferSource): ImageData | null;
 }
 
-export default function(opts: EmscriptenWasm.ModuleOpts): WebPModule;
+export default function(opts: EmscriptenWasm.ModuleOpts): Promise<WebPModule>;

--- a/codecs/webp/enc/example.html
+++ b/codecs/webp/enc/example.html
@@ -15,9 +15,7 @@
     return ctx.getImageData(0, 0, img.width, img.height);
   }
 
-
-  (async _ => {
-    const module = await webp_enc();
+  webp_enc().then(async module => {
     console.log('Version:', module.version().toString(16));
     const image = await loadImage('../../example.png');
     const result = module.encode(image.data, image.width, image.height, {
@@ -56,5 +54,5 @@
     const img = document.createElement('img');
     img.src = blobURL;
     document.body.appendChild(img);
-  })();
+  });
 </script>

--- a/codecs/webp/enc/example.html
+++ b/codecs/webp/enc/example.html
@@ -1,8 +1,6 @@
 <!doctype html>
 <script src='webp_enc.js'></script>
 <script>
-  const module = webp_enc();
-
   async function loadImage(src) {
     // Load image
     const img = document.createElement('img');
@@ -17,7 +15,9 @@
     return ctx.getImageData(0, 0, img.width, img.height);
   }
 
-  module.onRuntimeInitialized = async _ => {
+
+  (async _ => {
+    const module = await webp_enc();
     console.log('Version:', module.version().toString(16));
     const image = await loadImage('../../example.png');
     const result = module.encode(image.data, image.width, image.height, {
@@ -56,5 +56,5 @@
     const img = document.createElement('img');
     img.src = blobURL;
     document.body.appendChild(img);
-  };
+  })();
 </script>

--- a/codecs/webp/enc/webp_enc.d.ts
+++ b/codecs/webp/enc/webp_enc.d.ts
@@ -4,4 +4,4 @@ interface WebPModule extends EmscriptenWasm.Module {
   encode(data: BufferSource, width: number, height: number, options: EncodeOptions): Uint8Array | null;
 }
 
-export default function(opts: EmscriptenWasm.ModuleOpts): WebPModule;
+export default function(opts: EmscriptenWasm.ModuleOpts): Promise<WebPModule>;

--- a/src/codecs/util.ts
+++ b/src/codecs/util.ts
@@ -1,28 +1,19 @@
 type ModuleFactory<M extends EmscriptenWasm.Module> = (
   opts: EmscriptenWasm.ModuleOpts,
-) => M;
+) => Promise<M>;
 
 export function initEmscriptenModule<T extends EmscriptenWasm.Module>(
   moduleFactory: ModuleFactory<T>,
   wasmUrl: string,
 ): Promise<T> {
-  return new Promise((resolve) => {
-    const module = moduleFactory({
-      // Just to be safe, don't automatically invoke any wasm functions
-      noInitialRun: true,
-      locateFile(url: string): string {
-        // Redirect the request for the wasm binary to whatever webpack gave us.
-        if (url.endsWith('.wasm')) return wasmUrl;
-        return url;
-      },
-      onRuntimeInitialized() {
-        // An Emscripten is a then-able that resolves with itself, causing an infite loop when you
-        // wrap it in a real promise. Delete the `then` prop solves this for now.
-        // https://github.com/kripken/emscripten/issues/5820
-        delete (module as any).then;
-        resolve(module);
-      },
-    });
+  return moduleFactory({
+    // Just to be safe, don't automatically invoke any wasm functions
+    noInitialRun: true,
+    locateFile(url: string): string {
+      // Redirect the request for the wasm binary to whatever webpack gave us.
+      if (url.endsWith('.wasm')) return wasmUrl;
+      return url;
+    },
   });
 }
 


### PR DESCRIPTION
It seems a promise-based API was added to modularized Emscripten builds in response to https://github.com/emscripten-core/emscripten/issues/5820:

PR: https://github.com/emscripten-core/emscripten/pull/10697

Since consolidating C++ builds (#781), the `emscripten/emsdk` Docker image produces module factory functions that return a promise for the emscripten module. This PR:

* Fixes broken `webp` examples: `codecs/webp/enc/example.html` & `codecs/webp/dec/example.html` by using the new promise-based API.
* Adds type annotations to the module factory functions for each C++ codec (now they return a promise).
* Simplifies `initEmscriptenModule` to just call module factory.

PS: Thanks for all the work here. I've modeled the C++ builds for one of my projects on squoosh's codecs, which is how I ran into this. Much appreciated!