### PR TITLE
Autoformat staged C++ and Rust

### DIFF
--- a/codecs/avif/enc/avif_enc.cpp
+++ b/codecs/avif/enc/avif_enc.cpp
@@ -1,7 +1,6 @@
 #include <emscripten/bind.h>
 #include <emscripten/threading.h>
 #include <emscripten/val.h>
-#include <emscripten/threading.h>
 #include "avif/avif.h"
 
 using namespace emscripten;

--- a/codecs/oxipng/src/lib.rs
+++ b/codecs/oxipng/src/lib.rs
@@ -1,5 +1,5 @@
-use wasm_bindgen::prelude::*;
 use oxipng::AlphaOptim;
+use wasm_bindgen::prelude::*;
 
 mod malloc_shim;
 
@@ -8,14 +8,14 @@ pub mod parallel;
 
 #[wasm_bindgen]
 pub fn optimise(data: &[u8], level: u8) -> Vec<u8> {
-  let mut options = oxipng::Options::from_preset(level);
-  options.alphas.insert(AlphaOptim::Black);
-  options.alphas.insert(AlphaOptim::White);
-  options.alphas.insert(AlphaOptim::Up);
-  options.alphas.insert(AlphaOptim::Down);
-  options.alphas.insert(AlphaOptim::Left);
-  options.alphas.insert(AlphaOptim::Right);
+    let mut options = oxipng::Options::from_preset(level);
+    options.alphas.insert(AlphaOptim::Black);
+    options.alphas.insert(AlphaOptim::White);
+    options.alphas.insert(AlphaOptim::Up);
+    options.alphas.insert(AlphaOptim::Down);
+    options.alphas.insert(AlphaOptim::Left);
+    options.alphas.insert(AlphaOptim::Right);
 
-  options.deflate = oxipng::Deflaters::Libdeflater;
-  oxipng::optimize_from_memory(data, &options).unwrap_throw()
+    options.deflate = oxipng::Deflaters::Libdeflater;
+    oxipng::optimize_from_memory(data, &options).unwrap_throw()
 }

--- a/codecs/oxipng/src/parallel.rs
+++ b/codecs/oxipng/src/parallel.rs
@@ -1,4 +1,4 @@
-use crossbeam_channel::{Sender, Receiver, bounded};
+use crossbeam_channel::{bounded, Receiver, Sender};
 use once_cell::sync::OnceCell;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
@@ -35,7 +35,8 @@ extern "C" {
 //    shared memory and blocks the current thread until they're all grabbed.
 // 4) Provide a `worker_initializer` that is expected to be invoked from various workers,
 //    reads one `threadPtr` from the shared channel and starts running it.
-static CHANNEL: OnceCell<(Sender<rayon::ThreadBuilder>, Receiver<rayon::ThreadBuilder>)> = OnceCell::new();
+static CHANNEL: OnceCell<(Sender<rayon::ThreadBuilder>, Receiver<rayon::ThreadBuilder>)> =
+    OnceCell::new();
 
 #[wasm_bindgen]
 pub fn worker_initializer(num: usize) -> JsValue {

--- a/codecs/webp/dec/webp_dec.cpp
+++ b/codecs/webp/dec/webp_dec.cpp
@@ -17,7 +17,10 @@ val decode(std::string buffer) {
   int width, height;
   std::unique_ptr<uint8_t[]> rgba(
       WebPDecodeRGBA((const uint8_t*)buffer.c_str(), buffer.size(), &width, &height));
-  return rgba ? ImageData.new_(Uint8ClampedArray.new_(typed_memory_view(width * height * 4, rgba.get())), width, height) : val::null();
+  return rgba ? ImageData.new_(
+                    Uint8ClampedArray.new_(typed_memory_view(width * height * 4, rgba.get())),
+                    width, height)
+              : val::null();
 }
 
 EMSCRIPTEN_BINDINGS(my_module) {

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     }
   },
   "lint-staged": {
-    "*.{js,css,json,md,ts,tsx}": [
-      "prettier --write"
-    ]
+    "*.{js,css,json,md,ts,tsx}": "prettier --write",
+    "*.{c,h,cpp,hpp}": "clang-format -i",
+    "*.rs": "rustfmt"
   },
   "dependencies": {
     "wasm-feature-detect": "^1.2.9"


### PR DESCRIPTION
Adding autoformat for codec binding sources, and also fixed formatting of existing ones in the same commit.

It could be possible to set up installation of clang-format and rustfmt too, but it's a bit more involved, and, I think, given that those commands will only be executed if the author edits C++ or Rust, I think it's fair to assume they already have the necessary toolchains installed. If not, we can revisit this later.