### PR TITLE
Add “Generate CLI Invocation” button

### DIFF
--- a/src/client/lazy-app/Compress/Options/index.tsx
+++ b/src/client/lazy-app/Compress/Options/index.tsx
@@ -5,6 +5,7 @@ import 'add-css:./style.css';
 import { cleanSet, cleanMerge } from '../../util/clean-modify';
 
 import type { SourceImage, OutputType } from '..';
+import type SnackBarElement from 'shared/initial-app/custom-els/snack-bar';
 import {
   EncoderOptions,
   EncoderState,
@@ -21,6 +22,7 @@ import { Options as ResizeOptionsComponent } from 'features/processors/resize/cl
 import { generateCliInvocation } from '../../util/cli-invocation-generator';
 
 interface Props {
+  showSnack: SnackBarElement['showSnackbar'];
   mobileView: boolean;
   source?: SourceImage;
   encoderState?: EncoderState;
@@ -111,8 +113,7 @@ export default class Options extends Component<Props, State> {
       );
       navigator.clipboard.writeText(cliInvocation);
     } catch (e) {
-      // Show toast
-      console.error(e);
+      this.props.showSnack(e);
     }
   };
 

--- a/src/client/lazy-app/Compress/Options/index.tsx
+++ b/src/client/lazy-app/Compress/Options/index.tsx
@@ -18,6 +18,8 @@ import Select from './Select';
 import { Options as QuantOptionsComponent } from 'features/processors/quantize/client';
 import { Options as ResizeOptionsComponent } from 'features/processors/resize/client';
 
+import { generateCliInvocation } from '../../util/cli-invocation-generator';
+
 interface Props {
   mobileView: boolean;
   source?: SourceImage;
@@ -97,6 +99,23 @@ export default class Options extends Component<Props, State> {
     );
   };
 
+  private onCreateCLIInvocation = () => {
+    if (!this.props.encoderState) {
+      return;
+    }
+
+    try {
+      const cliInvocation = generateCliInvocation(
+        this.props.encoderState,
+        this.props.processorState,
+      );
+      navigator.clipboard.writeText(cliInvocation);
+    } catch (e) {
+      // Show toast
+      console.error(e);
+    }
+  };
+
   render(
     { source, encoderState, processorState, onEncoderOptionsChange }: Props,
     { supportedEncoderMap }: State,
@@ -110,7 +129,9 @@ export default class Options extends Component<Props, State> {
         <Expander>
           {!encoderState ? null : (
             <div>
-              <h3 class={style.optionsTitle}>Edit</h3>
+              <h3 class={style.optionsTitle}>
+                <button onClick={this.onCreateCLIInvocation}>CLI</button>Edit
+              </h3>
               <label class={style.sectionEnabler}>
                 <Checkbox
                   name="resize.enable"

--- a/src/client/lazy-app/Compress/index.tsx
+++ b/src/client/lazy-app/Compress/index.tsx
@@ -786,7 +786,7 @@ export default class Compress extends Component<Props, State> {
   }
 
   render(
-    { onBack }: Props,
+    { onBack, showSnack }: Props,
     { loading, sides, source, mobileView, preprocessorState }: State,
   ) {
     const [leftSide, rightSide] = sides;
@@ -794,6 +794,7 @@ export default class Compress extends Component<Props, State> {
 
     const options = sides.map((side, index) => (
       <Options
+        showSnack={showSnack}
         source={source}
         mobileView={mobileView}
         processorState={side.latestSettings.processorState}

--- a/src/client/lazy-app/util/cli-invocation-generator.ts
+++ b/src/client/lazy-app/util/cli-invocation-generator.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { EncoderState, ProcessorState } from '../feature-meta';
+
+// Maps our encoder.type values to CLI parameter names
+const typeMap = new Map<string, string>([
+  ['avif', '--avif'],
+  // ["jxl", "--jxl"],
+  ['mozJPEG', '--mozjpeg'],
+  ['oxiPNG', '--oxipng'],
+  ['webP', '--webp'],
+  // ["wp2", "--wp2"]
+]);
+
+// Same as JSON.stringify, but with single quotes around the entire value
+// so that shells don’t do weird stuff.
+function cliJson<T>(v: T): string {
+  return "'" + JSON.stringify(v) + "'";
+}
+
+export function generateCliInvocation(
+  encoder: EncoderState,
+  processor: ProcessorState,
+): string {
+  if (!typeMap.has(encoder.type)) {
+    throw Error(`Encoder ${encoder.type} is unsupported in the CLI`);
+  }
+  return [
+    'npx',
+    '@squoosh/cli',
+    ...(processor.resize.enabled
+      ? ['--resize', cliJson(processor.resize)]
+      : []),
+    ...(processor.quantize.enabled
+      ? ['--quant', cliJson(processor.quantize)]
+      : []),
+    typeMap.get(encoder.type)!,
+    cliJson(encoder.options),
+  ].join(' ');
+}

--- a/src/client/lazy-app/util/cli-invocation-generator.ts
+++ b/src/client/lazy-app/util/cli-invocation-generator.ts
@@ -16,11 +16,11 @@ import { EncoderState, ProcessorState } from '../feature-meta';
 // Maps our encoder.type values to CLI parameter names
 const typeMap = new Map<string, string>([
   ['avif', '--avif'],
-  // ["jxl", "--jxl"],
+  ["jxl", "--jxl"],
   ['mozJPEG', '--mozjpeg'],
   ['oxiPNG', '--oxipng'],
   ['webP', '--webp'],
-  // ["wp2", "--wp2"]
+  ["wp2", "--wp2"],
 ]);
 
 // Same as JSON.stringify, but with single quotes around the entire value


### PR DESCRIPTION
This PR adds a (completely unstyled) “CLI” button the `<Options>` component that copy a CLI command to the user’s clipboard.

![squoosh_svg_-_Squoosh](https://user-images.githubusercontent.com/234957/100745579-61feb600-33d7-11eb-89c1-57ffb6876212.png)
