### PR TITLE
Clarify CLI file size unit output

### DIFF
--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -19,11 +19,11 @@ function clamp(v, min, max) {
   return v;
 }
 
-const suffix = ['B', 'KB', 'MB'];
+const suffix = ['B', 'KiB', 'MiB'];
 function prettyPrintSize(size) {
   const base = Math.floor(Math.log2(size) / 10);
   const index = clamp(base, 0, 2);
-  return (size / 2 ** (10 * index)).toFixed(2) + suffix[index];
+  return (size / 2 ** (10 * index)).toFixed(2) + ' ' + suffix[index];
 }
 
 async function decodeFile(file) {


### PR DESCRIPTION
This patch clarifies that the file size output uses 1024-based calculations (KiB, MiB) instead of 1000-based ones (kB, MB). It also adds a space between the number and unit per the Unicode CLDR conventions (which can also be observed via the `Intl.NumberFormat` API).

Related (but out of scope for this patch): [DevTools uses 1000-based calculations and units in its UI.](https://goo.gle/devtools-si) Not sure if this is something you’d want to align on.