### PR TITLE
Restore focus outline on buttons

### DIFF
--- a/src/shared/prerendered-app/Intro/index.tsx
+++ b/src/shared/prerendered-app/Intro/index.tsx
@@ -312,7 +312,7 @@ export default class Intro extends Component<Props, State> {
               {demos.map((demo, i) => (
                 <li>
                   <button
-                    class="unbutton"
+                    class={'unbutton ' + style.sampleButton}
                     onClick={(event) => this.onDemoClick(i, event)}
                   >
                     <div>

--- a/src/shared/prerendered-app/Intro/style.css
+++ b/src/shared/prerendered-app/Intro/style.css
@@ -222,12 +222,13 @@
 .demo-icon-container {
   border-radius: var(--demo-size);
   position: relative;
-  overflow: hidden;
+  transition: box-shadow 250ms;
 }
 .demo-icon {
   width: var(--demo-size);
   height: var(--demo-size);
   display: block;
+  border-radius: 50%;
 }
 .demo-loader {
   composes: abs-fill from global;
@@ -245,5 +246,15 @@
 .drop-text {
   @media (max-width: 599px) {
     display: none;
+  }
+}
+
+.sample-button {
+  &:focus {
+    outline: 0;
+  }
+
+  &:focus-visible .demo-icon-container {
+    box-shadow: 0 0 0 4px var(--deep-blue), 0 0 0 8px var(--pink);
   }
 }

--- a/src/shared/prerendered-app/Intro/style.css
+++ b/src/shared/prerendered-app/Intro/style.css
@@ -251,7 +251,7 @@
 
 .sample-button {
   &:focus {
-    outline: 0;
+    outline: transparent solid 2px;
   }
 
   &:focus-visible .demo-icon-container {

--- a/src/shared/prerendered-app/util.css
+++ b/src/shared/prerendered-app/util.css
@@ -16,9 +16,5 @@
     font: inherit;
     padding: 0;
     margin: 0;
-
-    &:focus {
-      outline: none;
-    }
   }
 }


### PR DESCRIPTION
Hello there! ✨

Most buttons on the home page use the class `unbutton` to reset the default button styles such as background, border and font styles. Unfortunately, they also remove the focus outline, and do not declare any focus styles. This is an accessible issue, because it completely breaks keyboard navigation. This PR intends to restore the default browser outline for focusable buttons.