### PR TITLE
Fix wrong development script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm run build
 You can run the development server with:
 
 ```sh
-npm start
+npm run dev
 ```
 
 [squoosh]: https://squoosh.app


### PR DESCRIPTION
There is no `start` script in `package.json` but `dev` exists.