### PR TITLE
[CLI] allow passing entire directories as input

### DIFF
--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -187,7 +187,6 @@ async function getInputFiles(paths) {
   const validFiles = [];
 
   for (const path of paths) {
-    //allow paths ending in / of \ to get all files in that directory
     const files = (await fsp.lstat(path)).isDirectory()
       ? (await fsp.readdir(path)).map(file => join(path, file))
       : [path];

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -183,31 +183,37 @@ function progressTracker(results) {
   return tracker;
 }
 
-async function checkInputFilesValid(files) {
+async function getInputFiles(paths) {
   const validFiles = [];
 
-  for (const file of files) {
-    try {
-      await fsp.stat(file);
-    } catch (err) {
-      if (err.code === 'ENOENT') {
-        console.warn(
-          `Warning: Input file does not exist: ${resolvePath(file)}`,
-        );
-        continue;
-      } else {
-        throw err;
+  for (const path of paths) {
+    //allow paths ending in / of \ to get all files in that directory
+    const files = path.endsWith('/') || path.endsWith('\\')
+      ? await fs.readdir(paths)
+      : [path];
+    for (const file of files) {
+      try {
+        await fsp.stat(file);
+      } catch (err) {
+        if (err.code === 'ENOENT') {
+          console.warn(
+            `Warning: Input file does not exist: ${resolvePath(file)}`,
+          );
+          continue;
+        } else {
+          throw err;
+        }
       }
-    }
 
-    validFiles.push(file);
+      validFiles.push(file);
+    }
   }
 
   return validFiles;
 }
 
 async function processFiles(files) {
-  files = await checkInputFilesValid(files);
+  files = await getInputFiles(files);
 
   const parallelism = cpus().length;
 

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -188,7 +188,7 @@ async function getInputFiles(paths) {
 
   for (const path of paths) {
     //allow paths ending in / of \ to get all files in that directory
-    const files = path.endsWith('/') || path.endsWith('\\')
+    const files = (await fsp.lstat(path)).isDirectory()
       ? (await fsp.readdir(path)).map(file => join(path, file))
       : [path];
     for (const file of files) {

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -189,7 +189,7 @@ async function getInputFiles(paths) {
   for (const path of paths) {
     //allow paths ending in / of \ to get all files in that directory
     const files = path.endsWith('/') || path.endsWith('\\')
-      ? await fs.readdir(paths)
+      ? (await fsp.readdir(path)).map(file => join(path, file))
       : [path];
     for (const file of files) {
       try {


### PR DESCRIPTION
useful on windows where `./*` doesn't expend the contents of a directory, and unlike `./*` this method allows for spaces in filenames