### PR TITLE
[CLI] fix hanging when there are more files than cpu cores

### DIFF
--- a/cli/src/worker_pool.js
+++ b/cli/src/worker_pool.js
@@ -81,9 +81,9 @@ export default class WorkerPool {
   }
 
   async join() {
-    this.closing = true;
     this.jobQueue.writable.close();
     await this.done;
+    this.closing = true;
   }
 
   dispatchJob(msg) {


### PR DESCRIPTION
closes #925 

as far as i could tell, it looks like the issue was caused by `closing` being set to `true` before all of the jobs were completed, causing `_readLoop` to terminate workers instead of picking up the next job.