### PR TITLE
Disable Worker termination on dev

### DIFF
--- a/src/client/lazy-app/worker-bridge/index.ts
+++ b/src/client/lazy-app/worker-bridge/index.ts
@@ -58,9 +58,11 @@ for (const methodName of methodNames) {
           signal.removeEventListener('abort', onAbort);
 
           // Start a timer to clear up the worker.
-          this._workerTimeout = setTimeout(() => {
-            this._terminateWorker();
-          }, workerTimeout);
+          if (__PRODUCTION__) {
+            this._workerTimeout = setTimeout(() => {
+              this._terminateWorker();
+            }, workerTimeout);
+          }
         });
       });
 


### PR DESCRIPTION
This helps inspect the source code without it disappearing right from under your nose in 10 seconds.