### PR TITLE
Add support for pasting datauri

### DIFF
--- a/src/shared/prerendered-app/Intro/index.tsx
+++ b/src/shared/prerendered-app/Intro/index.tsx
@@ -60,8 +60,21 @@ async function getImageClipboardItem(
   items: ClipboardItem[],
 ): Promise<undefined | Blob> {
   for (const item of items) {
-    const type = item.types.find((type) => type.startsWith('image/'));
-    if (type) return item.getType(type);
+    const type = item.types.find(
+      (type) => type.startsWith('image/') || type === 'text/plain',
+    );
+    if (type) {
+      if (type.startsWith('image/')) {
+        return item.getType(type);
+      } else {
+        const blob = await item.getType(type);
+        const dataUrl = await blob.text();
+        if (dataUrl.startsWith('data:image/')) {
+          const response = await fetch(dataUrl);
+          return response.blob();
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Hello, a small PR to enable pasting images in the datauri format.

General testing in Chrome, I couldn't find any functionality that regressed when pasting in images this way.

Demo:
https://user-images.githubusercontent.com/3313870/105426014-4d55d600-5c42-11eb-8a1b-5339b57de832.mp4

