### PR TITLE
Don't render "OR Paste" when Clipboard API is unsupported

### DIFF
--- a/src/shared/prerendered-app/Intro/index.tsx
+++ b/src/shared/prerendered-app/Intro/index.tsx
@@ -281,13 +281,14 @@ export default class Intro extends Component<Props, State> {
                 </svg>
               </button>
               <div>
-                <span class={style.dropText}>Drop </span>OR{' '}
-                {supportsClipboardAPI ? (
-                  <button class={style.pasteBtn} onClick={this.onPasteClick}>
-                    Paste
-                  </button>
-                ) : (
-                  'Paste'
+                <span class={style.dropText}>Drop</span>
+                {supportsClipboardAPI && (
+                  <Fragment>
+                    <span> OR </span>
+                    <button class={style.pasteBtn} onClick={this.onPasteClick}>
+                      Paste
+                    </button>
+                  </Fragment>
                 )}
               </div>
             </div>

--- a/src/shared/prerendered-app/Intro/index.tsx
+++ b/src/shared/prerendered-app/Intro/index.tsx
@@ -1,4 +1,4 @@
-import { h, Component } from 'preact';
+import { h, Component, Fragment } from 'preact';
 
 import { linkRef } from 'shared/prerendered-app/util';
 import '../../custom-els/loading-spinner';


### PR DESCRIPTION
Hello,

When testing #944, I noticed that although Firefox doesn't support the pasting we still render some copy.

This PR prevents rendering "OR Paste" when Clipboard API is not fully supported.

Demo: https://user-images.githubusercontent.com/3313870/105429245-f1db1680-5c48-11eb-8a61-853560a9ac50.mp4

