### PR TITLE
Lengthen web app manifest description

### DIFF
--- a/src/static-build/index.tsx
+++ b/src/static-build/index.tsx
@@ -68,7 +68,7 @@ const toOutput: Output = {
       },
     ],
     description:
-      'Compress and compare images with different codecs, right in your browser.',
+      'Squoosh is an image compression web app that allows you to dive into the advanced options provided by various image compressors.',
     lang: 'en',
     categories: ['photo', 'productivity', 'utilities'],
     screenshots: [


### PR DESCRIPTION
Because of https://chromium-review.googlesource.com/c/chromium/src/+/2642690, this PR updates the web app manifest description to be longer than 80 characters so that the PWA bottom sheet UI shows up on Chrome for Android.

The new description comes from https://github.com/GoogleChromeLabs/squoosh#squoosh.

Context: https://github.com/GoogleChromeLabs/squoosh/pull/933#issue-554965271