### PR TITLE
Add back a loader customization for full URL

### DIFF
--- a/lib/omt.ejs
+++ b/lib/omt.ejs
@@ -16,8 +16,7 @@ if (!self.<%- amdFunctionName %>) {
   let registry = {};
 
   const singleRequire = (uri, parentUri) => {
-    let origURI = uri;
-    uri = new URL(uri + ".js", parentUri).href;
+    uri = uri.startsWith(location.origin) ? uri : new URL(uri + ".js", parentUri).href;
     return registry[uri] || (
       <% if (useEval) { %>
         fetch(uri)


### PR DESCRIPTION
Emscripten uses dynamic `import(fullUrlOfTheMainJS)` in generated Workers.

It appears that upstream rollup-plugin-off-main-thread never handled this correctly, but we had a customization in Squoosh loader template that allowed those anyway, which I removed together with most other customizations in #1007, thus breaking Emscripten codecs.

This adds a hotfix back, but we need to fix this properly upstream too (TBD separately).