### PR TITLE
[CLI] Handle subdirectories without failing

### DIFF
--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -75,7 +75,7 @@ async function getInputFiles(paths) {
 
   for (const inputPath of paths) {
     const files = (await fsp.lstat(inputPath)).isDirectory()
-      ? (await fsp.readdir(inputPath)).map((file) => path.join(inputPath, file))
+      ? (await fsp.readdir(inputPath, {withFileTypes: true})).filter(dirent => dirent.isFile()).map(dirent => path.join(inputPath, dirent.name))
       : [inputPath];
     for (const file of files) {
       try {


### PR DESCRIPTION
This is a rebase of #991 - I apparently still have some things to learn when it comes to git commands 😅

When you ask the CLI to minify an entire directory - something like this:
```
npx @squoosh/cli --webp "auto" /path/to/folder/
```
...and the directory contains subdirectories, squoosh will try to read the directories as files, and will fail spectacularly.

In the future, you might want to let the user choose to read the subdirectories recursively or something, but for the time being, this PR fixes the problem by making squoosh ignore any subdirectories.