### PR TITLE
Fix WebP sniffing some more

### DIFF
--- a/libsquoosh/src/codecs.ts
+++ b/libsquoosh/src/codecs.ts
@@ -282,7 +282,7 @@ export const codecs = {
   webp: {
     name: 'WebP',
     extension: 'webp',
-    detectors: [/^RIFF....WEBPVP8[LX ]/],
+    detectors: [/^RIFF....WEBPVP8[LX ]/s],
     dec: () => instantiateEmscriptenWasm(webpDec, webpDecWasm),
     enc: () => instantiateEmscriptenWasm(webpEnc, webpEncWasm),
     defaultEncoderOptions: {

--- a/src/client/lazy-app/util/index.ts
+++ b/src/client/lazy-app/util/index.ts
@@ -95,7 +95,7 @@ const magicNumberMapInput = [
   [/^I I/, 'image/tiff'],
   [/^II*/, 'image/tiff'],
   [/^MM\x00*/, 'image/tiff'],
-  [/^RIFF....WEBPVP8[LX ]/, 'image/webp'],
+  [/^RIFF....WEBPVP8[LX ]/s, 'image/webp'],
   [/^\xF4\xFF\x6F/, 'image/webp2'],
   [/^\x00\x00\x00 ftypavif\x00\x00\x00\x00/, 'image/avif'],
   [/^\xff\x0a/, 'image/jxl'],


### PR DESCRIPTION
I have a large folder of WebP images that I use to test squoosh. All of them are valid and can be opened in Firefox/Chrome, but `libSquoosh` is being very dramatic about two of them, telling me `[file] has an unsupported format`.

Here are the first chunks of the two failing images:
```
 82  73  70  70  10  19   0   0  87  69  66  80  86  80  56  32
[R] [I] [F] [F]  []  []  []  [] [W] [E] [B] [P] [V] [P] [8] [ ]
```
```
 82  73  70  70 236  10   0   0  87  69  66  80  86  80  56  76
[R] [I] [F] [F] [ì]  []  []  [] [W] [E] [B] [P] [V] [P] [8] [L]
```

And here are two functioning images for comparison:
```
 82  73  70  70 174  18   0   0  87  69  66  80  86  80  56  88
[R] [I] [F] [F] [®]  []  []  [] [W] [E] [B] [P] [V] [P] [8] [X]
```
```
 82  73  70  70 202 131   0   0  87  69  66  80  86  80  56  76
[R] [I] [F] [F] [Ê]  []  []  [] [W] [E] [B] [P] [V] [P] [8] [L]
```

The failing images both contain the code point `10`, which JavaScript interprets as a `newline`. RegEx (which `libSquoosh` uses to sniff the image encoding) won't match across newlines by default. For that to work, you have to add the `s` flag, which is what this PR does :)

For annoying legal reasons, I can't post the failing images publicly, but I can send one of them privately if you'd like me to.