### PR TITLE
Specify supported node versions

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -18,6 +18,9 @@
       "bin": {
         "cli": "src/index.js",
         "squoosh-cli": "src/index.js"
+      },
+      "engines": {
+        "node": " ^12.20.2 || ^14.13.1 || ^16.0.0 "
       }
     },
     "node_modules/@squoosh/lib": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -14,6 +14,9 @@
   "keywords": [],
   "author": "Google Chrome Developers <chromium-dev@google.com>",
   "license": "Apache-2.0",
+  "engines": {
+    "node": " ^12.20.2 || ^14.13.1 || ^16.0.0 "
+  },
   "dependencies": {
     "@squoosh/lib": "^0.2.0",
     "commander": "^7.2.0",

--- a/libsquoosh/package.json
+++ b/libsquoosh/package.json
@@ -13,6 +13,9 @@
   "keywords": [],
   "author": "Google Chrome Developers <chromium-dev@google.com>",
   "license": "Apache-2.0",
+  "engines": {
+    "node": " ^12.5.0 || ^14.0.0 || ^16.0.0 "
+  },
   "dependencies": {
     "web-streams-polyfill": "^3.0.3"
   },


### PR DESCRIPTION
Closes #1059 (or should it stay open to track docs?)

Supported Node versions are now specified in `package.json`, meaning npm will warn users that install on an unsupported version.

Note that these files are not up to date! A bunch of changes have been published to npm, but they are not present in the repository.