### PR TITLE
Add repo info in package.json so that people can backtrack from npm site

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -4,6 +4,11 @@
   "description": "A CLI for Squoosh",
   "public": true,
   "type": "module",
+  "homepage": "https://github.com/GoogleChromeLabs/squoosh",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoogleChromeLabs/squoosh.git"
+  },
   "bin": {
     "squoosh-cli": "src/index.js",
     "@squoosh/cli": "src/index.js"

--- a/libsquoosh/package.json
+++ b/libsquoosh/package.json
@@ -12,6 +12,11 @@
   },
   "keywords": [],
   "author": "Google Chrome Developers <chromium-dev@google.com>",
+  "homepage": "https://github.com/GoogleChromeLabs/squoosh",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GoogleChromeLabs/squoosh.git"
+  },
   "license": "Apache-2.0",
   "dependencies": {
     "web-streams-polyfill": "^3.0.3"


### PR DESCRIPTION
These changes may reflect on https://www.npmjs.com/package/@squoosh/cli and https://www.npmjs.com/package/@squoosh/lib pages to show the repo links - so that we can backtrack to this repo.

like:
![image](https://user-images.githubusercontent.com/12165822/122661722-e6b1f580-d1aa-11eb-8622-1e0a3cb862bb.png)
