### PR TITLE
libsquoosh/README: Add code example to resize with aspect ratio preserved.

### DIFF
--- a/libsquoosh/README.md
+++ b/libsquoosh/README.md
@@ -42,11 +42,19 @@ When an image has been ingested, you can start preprocessing it and encoding it 
 await image.decoded; //Wait until the image is decoded before running preprocessors. 
 
 const preprocessOptions = {
+  //When both width and height are specified, the image resized to specified size.
   resize: {
     enabled: true,
     width: 100,
     height: 50,
   }
+  /*
+  //When either width or height is specified, the image resized to specified size keeping aspect ratio.
+  resize: {
+    enabled: true,
+    width: 100,
+  }
+  */
 }
 await image.preprocess(preprocessOptions);
 


### PR DESCRIPTION
Add code example to make it easy to find out how to resize the image with aspect ratio preserved.