### PR TITLE
Prototyping alternative size change indicators

### DIFF
--- a/src/client/lazy-app/Compress/Results/index.tsx
+++ b/src/client/lazy-app/Compress/Results/index.tsx
@@ -110,7 +110,7 @@ export default class Results extends Component<Props, State> {
               <div class={style.percentOutput}>
                 {diff && diff !== 1 && (
                   <span class={style.sizeDirection}>
-                    {diff < 1 ? '↓' : '↑'}
+                    {diff < 1 ? '↓' : '+'}
                   </span>
                 )}
                 <span class={style.sizeValue}>{percent || 0}</span>

--- a/src/client/lazy-app/Compress/Results/style.css
+++ b/src/client/lazy-app/Compress/Results/style.css
@@ -191,9 +191,7 @@
   font-family: ui-monospace, monospace;
   opacity: 0.76;
   text-shadow: 0 2px rgba(0, 0, 0, 0.3);
-  font-size: 1.5rem;
-  position: relative;
-  top: 3px;
+  font-size: 0.75em;
 }
 
 .size-value {

--- a/src/client/lazy-app/Compress/Results/style.css
+++ b/src/client/lazy-app/Compress/Results/style.css
@@ -172,6 +172,7 @@
   display: grid;
   grid-template-columns: auto auto auto;
   line-height: 1;
+  font-size: 2.6rem;
 
   @media (min-width: 600px) {
     background: var(--main-theme-color);
@@ -185,9 +186,8 @@
 }
 
 .size-direction {
-  font-weight: 700;
   align-self: center;
-  font-family: sans-serif;
+  font-family: ui-monospace, monospace;
   opacity: 0.76;
   text-shadow: 0 2px rgba(0, 0, 0, 0.3);
   font-size: 1.5rem;
@@ -197,7 +197,6 @@
 
 .size-value {
   font-family: 'Roboto Mono Numbers';
-  font-size: 2.6rem;
   text-shadow: 0 2px rgba(0, 0, 0, 0.3);
 }
 
@@ -207,6 +206,7 @@
   top: 4px;
   opacity: 0.76;
   margin-left: 0.2rem;
+  font-size: 0.5em;
 }
 
 .download {

--- a/src/client/lazy-app/Compress/Results/style.css
+++ b/src/client/lazy-app/Compress/Results/style.css
@@ -173,6 +173,7 @@
   grid-template-columns: auto auto auto;
   line-height: 1;
   font-size: 2.6rem;
+  gap: 0.2rem;
 
   @media (min-width: 600px) {
     background: var(--main-theme-color);
@@ -205,7 +206,6 @@
   position: relative;
   top: 4px;
   opacity: 0.76;
-  margin-left: 0.2rem;
   font-size: 0.5em;
 }
 


### PR DESCRIPTION
This PR is thoughts on #984

I ended up preferring a `+` for when the image will be larger in size, and the `↓` unicode character for when it's smaller:

![Screen Shot 2021-07-09 at 10 40 12 AM](https://user-images.githubusercontent.com/1134620/125117216-c044f300-e0a2-11eb-8ed8-3ad8e7d768f4.png)
![Screen Shot 2021-07-09 at 10 40 19 AM](https://user-images.githubusercontent.com/1134620/125117218-c0dd8980-e0a2-11eb-9568-a95a88b49a65.png)

I also switched to the monospace font for the arrow and plus, which in general should use a bolder symbol across platforms. if this arrow is problematic, we could use an inline SVG instead and own the vector ourselves to normalize it. 

All in all, _I felt_ switching to a plus instead of an up arrow was enough to take the subtly out, what do y'all think?