### PR TITLE
Allow overwriting the filename in the Imagepool constructor

### DIFF
--- a/libsquoosh/src/index.js
+++ b/libsquoosh/src/index.js
@@ -198,8 +198,8 @@ class ImagePool {
    * @param {number} [threads] - Number of concurrent image processes to run in the pool. Defaults to the number of CPU cores in the system.
    * @param {string | null} - Customize the entry filename for squoosh. 
    */
-  constructor(threads, filename) {
-    this.workerPool = new WorkerPool(threads || cpus().length, typeof filename === 'undefined' || filename === null ? __filename : filename);
+  constructor(threads, filename = __filename) {
+    this.workerPool = new WorkerPool(threads || cpus().length, filename);
   }
 
   /**

--- a/libsquoosh/src/index.js
+++ b/libsquoosh/src/index.js
@@ -196,10 +196,10 @@ class ImagePool {
   /**
    * Create a new pool.
    * @param {number} [threads] - Number of concurrent image processes to run in the pool. Defaults to the number of CPU cores in the system.
-   * @param {string} - Customize the entry filename for squoosh. 
+   * @param {string | null} - Customize the entry filename for squoosh. 
    */
   constructor(threads, filename) {
-    this.workerPool = new WorkerPool(threads || cpus().length, typeof filename === 'undefined' ? __filename : filename);
+    this.workerPool = new WorkerPool(threads || cpus().length, typeof filename === 'undefined' || filename === null ? __filename : filename);
   }
 
   /**

--- a/libsquoosh/src/index.js
+++ b/libsquoosh/src/index.js
@@ -196,9 +196,10 @@ class ImagePool {
   /**
    * Create a new pool.
    * @param {number} [threads] - Number of concurrent image processes to run in the pool. Defaults to the number of CPU cores in the system.
+   * @param {string} - Customize the entry filename for squoosh. 
    */
-  constructor(threads) {
-    this.workerPool = new WorkerPool(threads || cpus().length, __filename);
+  constructor(threads, filename) {
+    this.workerPool = new WorkerPool(threads || cpus().length, typeof filename === 'undefined' ? __filename : filename);
   }
 
   /**


### PR DESCRIPTION
Whenever you build squoosh in a node project (for example with webpack), the reference to the `__filename` (in https://github.com/GoogleChromeLabs/squoosh/blob/dev/libsquoosh/src/index.js#L201) is not going to be correct.

This PR allows people to customize it.

For example:
You could copy the contents of `./node_modules/@squoosh/lib/build` to  `./build/squoosh`,
and then use `new ImagePool(1, __dirname + '/squoosh/index.js');`