### PR TITLE
Create an upper limit for scaling

### DIFF
--- a/src/client/lazy-app/Compress/Output/custom-els/PinchZoom/index.ts
+++ b/src/client/lazy-app/Compress/Output/custom-els/PinchZoom/index.ts
@@ -81,6 +81,7 @@ function createPoint(): SVGPoint {
 }
 
 const MIN_SCALE = 0.01;
+const MAX_SCALE = 655.36; // 65536%
 
 export default class PinchZoom extends HTMLElement {
   // The element that we'll transform.
@@ -174,9 +175,19 @@ export default class PinchZoom extends HTMLElement {
    * Update the stage with a given scale/x/y.
    */
   setTransform(opts: SetTransformOpts = {}) {
-    const { scale = this.scale, allowChangeEvent = false } = opts;
+    const { allowChangeEvent = false } = opts;
 
-    let { x = this.x, y = this.y } = opts;
+    let { scale = this.scale, x = this.x, y = this.y } = opts;
+
+
+    if (scale > MAX_SCALE) {
+      if (this.scale === MAX_SCALE) return; // Already at max scale
+      // undo effects of the target scale (NOTE: This code currently produces slightly inaccurate results)
+      const scaleDiff = MAX_SCALE / scale;
+      scale = MAX_SCALE;
+      x = x * scaleDiff;
+      y = y * scaleDiff;
+    }
 
     // If we don't have an element to position, just set the value as given.
     // We'll check bounds later.


### PR DESCRIPTION
This pull request is an attempt to create an upper limit to how far the user can zoom in, in order to prevent bugs related to floating point inaccuracy and reaching "Infinite" zoom when scrolling far enough

The reason this changes "setTransform" instead of the lower level "_updateTransform" function is to prevent incorrect x and y values from being applied.

Note that this current implementation seems to behave erratically when after zooming in to the max value the user pans the image and attempts to zoom in further. Additionally, my current implementation of correcting for the new zoom value seems to be slightly inaccurate and shift the image when reaching the max value (hence the return if the scale is already maximum).

Also, the number input box for zoom probably needs to have a `max` attribute set to the same value as what's decided to be the maximum.

This should fix #1091 