### PR TITLE
Max cap on scale #905

### DIFF
--- a/src/client/lazy-app/Compress/Output/custom-els/PinchZoom/index.ts
+++ b/src/client/lazy-app/Compress/Output/custom-els/PinchZoom/index.ts
@@ -81,6 +81,7 @@ function createPoint(): SVGPoint {
 }
 
 const MIN_SCALE = 0.01;
+const MAX_SCALE = 1000000;
 
 export default class PinchZoom extends HTMLElement {
   // The element that we'll transform.
@@ -243,6 +244,9 @@ export default class PinchZoom extends HTMLElement {
   ) {
     // Avoid scaling to zero
     if (scale < MIN_SCALE) return;
+
+    // Avoid scaling to very large values
+    if (scale > MAX_SCALE) return;
 
     // Return if there's no change
     if (scale === this.scale && x === this.x && y === this.y) return;

--- a/src/client/lazy-app/Compress/Output/custom-els/PinchZoom/index.ts
+++ b/src/client/lazy-app/Compress/Output/custom-els/PinchZoom/index.ts
@@ -81,7 +81,7 @@ function createPoint(): SVGPoint {
 }
 
 const MIN_SCALE = 0.01;
-const MAX_SCALE = 1000000;
+const MAX_SCALE = 100000;
 
 export default class PinchZoom extends HTMLElement {
   // The element that we'll transform.


### PR DESCRIPTION
Adds max cap scaling

Adding very large value for scroll or scrolling too much for Zoom can lead to unexpected behavior in many cases.

Behavior I can reproduce:
In Mozilla, the browser simply crashes with large value
In chrome, zoom leads to Infinity value and the website stops responding

Issue linked #905 

Solutions I could think of :-
1 - To add max cap on scaling
2 - There could be a notification to user that large value of scaling can lead to breakage in computation, but user can click okay and continue.
3 - Check at which point the zooming will lead to no change in result, like when we reach a zoomed single pixel, then just keep increasing the scale without actually zooming.

The first was the easiest to implement. PTAL,
Thanks


