### PR TITLE
Stable mousewheel scrolling, one wheel up then one wheel down should go back to same zoom

### DIFF
--- a/src/client/lazy-app/Compress/Output/custom-els/PinchZoom/index.ts
+++ b/src/client/lazy-app/Compress/Output/custom-els/PinchZoom/index.ts
@@ -300,9 +300,13 @@ export default class PinchZoom extends HTMLElement {
       deltaY *= 15;
     }
 
+    const zoomingOut = deltaY > 0;
+
     // ctrlKey is true when pinch-zooming on a trackpad.
     const divisor = ctrlKey ? 100 : 300;
-    const scaleDiff = 1 - deltaY / divisor;
+    // when zooming out, invert the delta and the ratio to keep zoom stable
+    const ratio = 1 - (zoomingOut ? -deltaY : deltaY) / divisor;
+    const scaleDiff = zoomingOut ? 1 / ratio : ratio;
 
     this._applyChange({
       scaleDiff,


### PR DESCRIPTION
I like to zoom in and out on the images, but I've noticed that zooming out after zooming in doesn't go back to where you came from.
i.e., one click of the wheel to zoom in, then one click to zoom out should be the same zoom, yet it isn't.

This is because currently zooming in scales by 0.66666 and zooming out scales by 1.33333 (depends on mouse/OS settings I presume, but for me that's what it is, 100 pixels).

Current behaviour:
`100% -> zoom in -> 133% -> zoom out -> 89% 😬 -> zoom in -> 119% 😬`

One method to fix this would be to have one multiplier for zooming in and use the inverse (1/multiplier) for zooming out.
I do that in this PR.

This PR's behaviour:
`100% -> zoom in -> 133% -> zoom out -> 100% 👌 -> zoom in 133% etc`


Another method would be to have more fixed increments instead of relying on a multiplier, for example:
100, 125, 150, 200, 300, 400, 600, 800, 1000 (... not sure what comes next)
100, 75, 66, 50, 33, 25, 10, 5, 2
Those values sound sensible to me.
At the end of the day, as long as I can zoom in 3 times, then zoom out 3 times, and end back where I started, I'm happy :)