### PR TITLE
Fix horizontal scroll on option elements on mobile

### DIFF
--- a/src/client/lazy-app/Compress/Options/style.css
+++ b/src/client/lazy-app/Compress/Options/style.css
@@ -1,6 +1,7 @@
 .options-scroller {
   --horizontal-padding: 15px;
   border-radius: var(--scroller-radius);
+  overflow: hidden;
 
   /* At smaller widths, the multi-panel handles the scrolling */
   @media (min-width: 600px) {


### PR DESCRIPTION
Fixes #903, which wasn't just an iOS issue in the end.