### PR TITLE
Improve `encode` API and its types

### DIFF
--- a/libsquoosh/src/index.ts
+++ b/libsquoosh/src/index.ts
@@ -26,6 +26,12 @@ type PreprocessOptions = {
   quant?: QuantOptions;
   rotate?: RotateOptions;
 };
+type EncodeResult = {
+  optionsUsed: object;
+  binary: Uint8Array;
+  extension: string;
+  size: number;
+};
 
 async function decodeFile({
   file,
@@ -83,7 +89,7 @@ async function encodeImage({
   encConfig: any;
   optimizerButteraugliTarget: number;
   maxOptimizerRounds: number;
-}) {
+}): Promise<EncodeResult> {
   let binary: Uint8Array;
   let optionsUsed = encConfig;
   const encoder = await encoders[encName].enc();
@@ -172,7 +178,7 @@ class Image {
   public file: ArrayBuffer | ArrayLike<number>;
   public workerPool: WorkerPool<JobMessage, any>;
   public decoded: Promise<{ bitmap: ImageData }>;
-  public encodedWith: { [key: string]: any };
+  public encodedWith: { [key in EncoderKey]?: Promise<EncodeResult> };
 
   constructor(
     workerPool: WorkerPool<JobMessage, any>,

--- a/libsquoosh/src/index.ts
+++ b/libsquoosh/src/index.ts
@@ -32,6 +32,14 @@ type EncodeResult = {
   extension: string;
   size: number;
 };
+type EncoderOptions = {
+  mozjpeg?: Partial<MozJPEGEncodeOptions>;
+  webp?: Partial<WebPEncodeOptions>;
+  avif?: Partial<AvifEncodeOptions>;
+  jxl?: Partial<JxlEncodeOptions>;
+  wp2?: Partial<WP2EncodeOptions>;
+  oxipng?: Partial<OxiPngEncodeOptions>;
+};
 
 async function decodeFile({
   file,
@@ -221,19 +229,12 @@ class Image {
    * @param {object} encodeOptions - An object with encoders to use, and their settings.
    * @returns {Promise<void>} - A promise that resolves when the image has been encoded with all the specified encoders.
    */
-  async encode(
+  async encode<T extends EncoderOptions>(
     encodeOptions: {
       optimizerButteraugliTarget?: number;
       maxOptimizerRounds?: number;
-    } & {
-      mozjpeg?: Partial<MozJPEGEncodeOptions>;
-      webp?: Partial<WebPEncodeOptions>;
-      avif?: Partial<AvifEncodeOptions>;
-      jxl?: Partial<JxlEncodeOptions>;
-      wp2?: Partial<WP2EncodeOptions>;
-      oxipng?: Partial<OxiPngEncodeOptions>;
-    } = {},
-  ): Promise<void> {
+    } & T,
+  ): Promise<{ [key in keyof T]: EncodeResult }> {
     const { bitmap } = await this.decoded;
     for (const [name, options] of Object.entries(encodeOptions)) {
       if (!Object.keys(encoders).includes(name)) {
@@ -257,6 +258,7 @@ class Image {
       });
     }
     await Promise.all(Object.values(this.encodedWith));
+    return this.encodedWith as { [key in keyof T]: EncodeResult };
   }
 }
 


### PR DESCRIPTION
Hey @surma,

I wanted to better type the API and improve the API we provide to the users overall so this time I tried some new things for the `encode` call:
* Improved typing of `encodedWith` property. Instead of it being `any` now, it is a type with the returned properties on it.
* Updated `Image.prototype.encode` to return and set `encodedWith` to the resolved promise values. Since we already resolve the values in the `encode` call users don't need to `await` on the values explicitly. I think this provides a better API.
* Updated `Image.prototype.encode` to return encoded images directly to the caller, so users will be able to do `const { mozjpeg: { binary }  } = await image.encode({ mozjpeg: {} })`. This provides a type safer API to the users since they will know that `mozjpeg` property will directly exist.

One of the cons of returning the `encodedWith` property directly to the caller in `encode` call is that, if they change the return value, the property will also change:
```
const result = await image.encode({ oxipng: {} });
result.oxipng = null;
console.log(image.encodedWith.oxipng.binary);
```
will throw since `image.encodedWith.oxipng` will be null.

Let me know if these ideas make sense or which ones we should keep. Personally, we should keep better typing for `encodedWith` for any case but we can discuss pros and cons of other changes :)

If it makes sense, we can update the README as well.