### PR TITLE
Tidy up CLI implementation

### DIFF
--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -10,6 +10,8 @@ import kleur from 'kleur';
 
 import { ImagePool, preprocessors, encoders } from '@squoosh/lib';
 
+const spinner = ora();
+
 function clamp(v, min, max) {
   if (v < min) return min;
   if (v > max) return max;
@@ -24,7 +26,6 @@ function prettyPrintSize(size) {
 }
 
 function progressTracker(results) {
-  const spinner = ora();
   const tracker = {};
   tracker.spinner = spinner;
   tracker.progressOffset = 0;
@@ -168,10 +169,13 @@ async function processFiles(files) {
       maxOptimizerRounds: Number(program.opts().maxOptimizerRounds),
     };
     for (const encName of Object.keys(encoders)) {
-      if (!program.opts()[encName]) {
+      const encParam = program.opts()[encName];
+      if (!encParam) {
         continue;
       }
-      const encParam = program.opts()[encName];
+      if (!(typeof encParam === "string")) {
+        throw new Error(`Invalid argument specified for "${encName}". Missing encoding configuration.`)
+      }
       const encConfig =
         encParam.toLowerCase() === 'auto' ? 'auto' : JSON5.parse(encParam);
       encodeOptions[encName] = encConfig;
@@ -233,4 +237,4 @@ for (const [key, value] of Object.entries(encoders)) {
   );
 }
 
-program.parse(process.argv);
+await program.parseAsync(process.argv);


### PR DESCRIPTION
A couple of issues while working on it:
1. The `processFiles` function is `async`. If it would throw an error,
then `commander` wouldn't properly catch the error, which results in
an uncaught promise rejection. Instead, we should be using `parseAsync`,
which can handle an async action
2. If the user would specify the encoder, but without encoding configuration,
then the CLI would crash. Now, double check that we the user passes in
a string and, if not, throw a nicer error.
3. For some reason, creating the `ora` spinner in the `progressTracker`
function results in leaked listeners when listening on `stdout`. Presumably
that's because `commander` already listens to it, but I don't know for sure.
If we instead call `ora` in the module scope, it can attach to the proper
outputstream and ensure that the leak is prevented.