### PR TITLE
Refactor CLI to perform batch processing

### DIFF
--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -25,37 +25,39 @@ function prettyPrintSize(size) {
   return (size / 2 ** (10 * index)).toFixed(2) + suffix[index];
 }
 
-function progressTracker(results) {
+function progressTracker(fileResults) {
   const tracker = {};
   tracker.spinner = spinner;
   tracker.progressOffset = 0;
-  tracker.totalOffset = 0;
+  tracker.total = 0;
   let status = '';
   tracker.setStatus = (text) => {
     status = text || '';
     update();
   };
   let progress = '';
-  tracker.setProgress = (done, total) => {
-    spinner.prefixText = kleur.dim(`${done}/${total}`);
-    const completeness =
-      (tracker.progressOffset + done) / (tracker.totalOffset + total);
+  tracker.setProgress = (done) => {
+    const progressWithOffset = tracker.progressOffset + done;
+    spinner.text = kleur.dim(`${progressWithOffset}/${tracker.total}`);
+    const completeness = progressWithOffset / tracker.total;
     progress = kleur.cyan(
       `▐${'▨'.repeat((completeness * 10) | 0).padEnd(10, '╌')}▌ `,
     );
     update();
   };
   function update() {
-    spinner.text = progress + kleur.bold(status) + getResultsText();
+    spinner.prefixText =
+      getResultsText() + '\n' + progress + kleur.bold(status);
   }
   tracker.finish = (text) => {
-    spinner.succeed(kleur.bold(text) + getResultsText());
+    update();
+    spinner.succeed(kleur.bold(text));
   };
   function getResultsText() {
     let out = '';
-    for (const result of results.values()) {
+    for (const result of fileResults) {
       out += `\n ${kleur.cyan(result.file)}: ${prettyPrintSize(result.size)}`;
-      for (const { outputFile, size: outputSize, infoText } of result.outputs) {
+      for (const { outputFile, outputSize, infoText } of result.outputs) {
         out += `\n  ${kleur.dim('└')} ${kleur.cyan(
           outputFile.padEnd(5),
         )} → ${prettyPrintSize(outputSize)}`;
@@ -102,23 +104,8 @@ async function getInputFiles(paths) {
   return validFiles;
 }
 
-async function processFiles(files) {
-  files = await getInputFiles(files);
-
-  const imagePool = new ImagePool(cpus().length);
-
-  const results = new Map();
-  const progress = progressTracker(results);
-
-  progress.setStatus('Decoding...');
-  progress.totalOffset = files.length;
-  progress.setProgress(0, files.length);
-
-  // Create output directory
-  await fsp.mkdir(program.opts().outputDir, { recursive: true });
-
-  let decoded = 0;
-  let decodedFiles = await Promise.all(
+async function decodeImages(imagePool, results, files) {
+  return Promise.all(
     files.map(async (file) => {
       const buffer = await fsp.readFile(file);
       const image = imagePool.ingestImage(buffer);
@@ -128,36 +115,13 @@ async function processFiles(files) {
         size: (await image.decoded).size,
         outputs: [],
       });
-      progress.setProgress(++decoded, files.length);
       return image;
     }),
   );
+}
 
-  const preprocessOptions = {};
-
-  for (const preprocessorName of Object.keys(preprocessors)) {
-    if (!program.opts()[preprocessorName]) {
-      continue;
-    }
-    preprocessOptions[preprocessorName] = JSON5.parse(
-      program.opts()[preprocessorName],
-    );
-  }
-
-  for (const image of decodedFiles) {
-    image.preprocess(preprocessOptions);
-  }
-
-  await Promise.all(decodedFiles.map((image) => image.decoded));
-
-  progress.progressOffset = decoded;
-  progress.setStatus(
-    'Encoding ' + kleur.dim(`(${imagePool.workerPool.numWorkers} threads)`),
-  );
-  progress.setProgress(0, files.length);
-
-  const jobs = [];
-  let jobsStarted = 0;
+async function encodeImages(decodedFiles, results, progress) {
+  let jobs = [];
   let jobsFinished = 0;
   for (const image of decodedFiles) {
     const originalFile = results.get(image).file;
@@ -173,14 +137,15 @@ async function processFiles(files) {
       if (!encParam) {
         continue;
       }
-      if (!(typeof encParam === "string")) {
-        throw new Error(`Invalid argument specified for "${encName}". Missing encoding configuration.`)
+      if (!(typeof encParam === 'string')) {
+        throw new Error(
+          `Invalid argument specified for "${encName}". Missing encoding configuration.`,
+        );
       }
       const encConfig =
         encParam.toLowerCase() === 'auto' ? 'auto' : JSON5.parse(encParam);
       encodeOptions[encName] = encConfig;
     }
-    jobsStarted++;
     const job = image.encode(encodeOptions).then(async () => {
       jobsFinished++;
       const outputPath = path.join(
@@ -195,17 +160,90 @@ async function processFiles(files) {
           .get(image)
           .outputs.push(Object.assign(await output, { outputFile }));
       }
-      progress.setProgress(jobsFinished, jobsStarted);
+      progress.setProgress(jobsFinished);
     });
     jobs.push(job);
   }
-
-  // update the progress to account for multi-format
-  progress.setProgress(jobsFinished, jobsStarted);
-  // Wait for all jobs to finish
   await Promise.all(jobs);
+}
+
+async function processFiles(files) {
+  files = await getInputFiles(files);
+
+  const parallelExecutionLimit = cpus().length;
+  const imagePool = new ImagePool(parallelExecutionLimit);
+
+  // Create output directory
+  await fsp.mkdir(program.opts().outputDir, { recursive: true });
+
+  const preprocessOptions = {};
+
+  for (const preprocessorName of Object.keys(preprocessors)) {
+    if (!program.opts()[preprocessorName]) {
+      continue;
+    }
+    preprocessOptions[preprocessorName] = JSON5.parse(
+      program.opts()[preprocessorName],
+    );
+  }
+
+  const fileResults = [];
+  const progress = progressTracker(fileResults);
+  progress.total = files.length;
+
+  for (
+    let fileLimit = 0;
+    fileLimit < files.length;
+    fileLimit += parallelExecutionLimit
+  ) {
+    // Make sure to only use the results in this for-loop. Otherwise, we keep hold of the memory across jobs, leading to OOMs.
+    const results = new Map();
+
+    const fromIndex = fileLimit;
+    const toIndex = Math.min(fileLimit + parallelExecutionLimit, files.length);
+
+    progress.setStatus('Decoding...');
+    progress.progressOffset = fromIndex;
+    progress.setProgress(0);
+
+    const decodedFiles = await decodeImages(
+      imagePool,
+      results,
+      files.slice(fromIndex, toIndex),
+    );
+
+    for (const image of decodedFiles) {
+      image.preprocess(preprocessOptions);
+    }
+
+    await Promise.all(decodedFiles.map((image) => image.decoded));
+
+    progress.setStatus(
+      'Encoding ' + kleur.dim(`(${imagePool.workerPool.numWorkers} threads)`),
+    );
+
+    await encodeImages(decodedFiles, results, progress);
+
+    for (const result of results.values()) {
+      fileResults.push({
+        file: result.file,
+        size: result.size,
+        outputs: result.outputs.map(
+          ({ outputFile, size: outputSize, infoText }) => {
+            return {
+              outputSize,
+              outputFile,
+              infoText,
+            };
+          },
+        ),
+      });
+    }
+  }
+
   await imagePool.close();
-  progress.finish('Squoosh results:');
+
+  progress.finish(`Successfully compressed all ${files.length} images`);
 }
 
 program

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -10,6 +10,8 @@ import kleur from 'kleur';
 
 import { ImagePool, preprocessors, encoders } from '@squoosh/lib';
 
+const spinner = ora();
+
 function clamp(v, min, max) {
   if (v < min) return min;
   if (v > max) return max;
@@ -24,7 +26,6 @@ function prettyPrintSize(size) {
 }
 
 function progressTracker(results) {
-  const spinner = ora();
   const tracker = {};
   tracker.spinner = spinner;
   tracker.progressOffset = 0;
@@ -168,10 +169,13 @@ async function processFiles(files) {
       maxOptimizerRounds: Number(program.opts().maxOptimizerRounds),
     };
     for (const encName of Object.keys(encoders)) {
-      if (!program.opts()[encName]) {
+      const encParam = program.opts()[encName];
+      if (!encParam) {
         continue;
       }
-      const encParam = program.opts()[encName];
+      if (!(typeof encParam === "string")) {
+        throw new Error(`Invalid argument specified for "${encName}". Missing encoding configuration.`)
+      }
       const encConfig =
         encParam.toLowerCase() === 'auto' ? 'auto' : JSON5.parse(encParam);
       encodeOptions[encName] = encConfig;
@@ -233,4 +237,4 @@ for (const [key, value] of Object.entries(encoders)) {
   );
 }
 
-program.parse(process.argv);
+await program.parseAsync(process.argv);


### PR DESCRIPTION
To avoid memory pressure by a complete sequential pipeline, instead
we can refactor the CLI to perform batch processing. For the number
of threads that Squoosh spawns, perform decoding and encoding in
sequence. Then, move on the next batch (if it exists).

I have confirmed that compressing 300 high resolution images works
with batch processing.

To make sure that the progress is appropriately shown, the
already-encoded images are now shown in the results, while the CLI
is doing its work. At the end, rather than printing all results
again, it only prints the total number of images. Otherwise, it
would result in a lot of duplicate console spam, which is not
desirable.

To make sure that all numbers are correct, the progress tracker is
refactored to instead use `progressOffset` to keep track of previous
batches. Additionally, rather than having the `total` set every
single time, it now sets it once at initialization (with the number
of files in total to compress)

Fixes #1012

(This builds upon #1172)