### PR TITLE
Publish codecs types in npm too

### DIFF
--- a/libsquoosh/lib/move-d-ts.js
+++ b/libsquoosh/lib/move-d-ts.js
@@ -8,6 +8,8 @@ const libSquooshTypesOutputDir = path.resolve('build', 'libsquoosh', 'types');
 const codecsDir = path.resolve('..', 'codecs');
 const codecsTypesOutputDir = path.resolve('build', 'codecs');
 
+const buildDir = path.resolve('build');
+
 async function getFilesRecursive(from) {
   const filesOrDirectories = await fs.promises.readdir(from, {
     withFileTypes: true,
@@ -52,7 +54,48 @@ async function copyCodecsTypes() {
   await copyTypes(codecsDir, codecsTypesOutputDir);
 }
 
+async function copyReferencedDeclarationFiles() {
+  await Promise.all([
+    fs.promises.copyFile(
+      path.resolve('..', 'missing-types.d.ts'),
+      path.resolve(buildDir, 'missing-types.d.ts'),
+    ),
+    fs.promises.copyFile(
+      path.resolve('..', 'emscripten-types.d.ts'),
+      path.resolve(buildDir, 'emscripten-types.d.ts'),
+    ),
+    fs.promises.copyFile(
+      path.resolve('src', 'missing-types.d.ts'),
+      path.resolve(buildDir, 'libsquoosh', 'types', 'missing-types.d.ts'),
+    ),
+    fs.promises.copyFile(
+      path.resolve('src', 'WebAssembly.d.ts'),
+      path.resolve(buildDir, 'libsquoosh', 'types', 'WebAssembly.d.ts'),
+    ),
+  ]);
+}
+
+// We need to import our needed ambient module declarations via triple slash directive
+// However, at the place of import, ts compiler rewrites the path to be absolute and
+// our import of "missing-types" in "index.d.ts" is not found
+// meaning that some of the globally needed modules are not available: EmscriptenWasm, WebAssembly etc.
+// This step here rewrites the absolute path to be a relative path
+// so that our reference to "missing-types" work and the types are found
+async function fixReferencePathOfMissingTypes() {
+  const indexTypesPath = path.resolve(libSquooshTypesOutputDir, 'index.d.ts');
+  const indexTypesContent = (
+    await fs.promises.readFile(indexTypesPath)
+  ).toString();
+  const updatedIndexTypesContent = indexTypesContent.replace(
+    'libsquoosh/src/',
+    './',
+  );
+  await fs.promises.writeFile(indexTypesPath, updatedIndexTypesContent);
+}
+
 (async () => {
   await copyLibSquooshTypes();
   await copyCodecsTypes();
+  await copyReferencedDeclarationFiles();
+  await fixReferencePathOfMissingTypes();
 })();

--- a/libsquoosh/lib/move-d-ts.js
+++ b/libsquoosh/lib/move-d-ts.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const del = require('del');
 const path = require('path');
 
 const tsOutputDir = path.resolve('..', '.tmp', 'ts', 'libsquoosh');
@@ -15,15 +14,20 @@ async function getFilesRecursive(from) {
   });
 
   const allFiles = await Promise.all(
-    filesOrDirectories.flatMap((fileOrDirectory) => {
+    filesOrDirectories.map((fileOrDirectory) => {
       if (fileOrDirectory.isFile()) {
         return path.resolve(from, fileOrDirectory.name);
+      } else if (
+        fileOrDirectory.isDirectory() &&
+        fileOrDirectory.name !== 'node_modules'
+      ) {
+        return getFilesRecursive(path.resolve(from, fileOrDirectory.name));
       }
 
-      return getFilesRecursive(path.resolve(from, fileOrDirectory.name));
+      return [];
     }),
   );
-  return allFiles.flatMap((x) => x);
+  return allFiles.flat();
 }
 
 async function copyTypes(from, to) {

--- a/libsquoosh/package.json
+++ b/libsquoosh/package.json
@@ -4,7 +4,7 @@
   "description": "A Node library for Squoosh",
   "public": true,
   "main": "./build/index.js",
-  "types": "./build/index.d.ts",
+  "types": "./build/libsquoosh/types/index.d.ts",
   "files": [
     "/build/*"
   ],

--- a/libsquoosh/package.json
+++ b/libsquoosh/package.json
@@ -32,7 +32,7 @@
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-commonjs": "^18.0.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
-    "@types/node": "^15.6.1",
+    "@types/node": "^17.0.18",
     "rollup": "^2.46.0",
     "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.1.3",

--- a/libsquoosh/src/index.ts
+++ b/libsquoosh/src/index.ts
@@ -1,3 +1,5 @@
+/// <reference path="./missing-types.d.ts" />
+
 import { isMainThread } from 'worker_threads';
 
 import {

--- a/libsquoosh/src/missing-types.d.ts
+++ b/libsquoosh/src/missing-types.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../missing-types.d.ts" />
+/// <reference path="./WebAssembly.d.ts" />
 
 declare module 'asset-url:*' {
   const value: string;
@@ -40,4 +41,3 @@ type WebGLRenderingContext = never;
 type MessageEvent = never;
 
 type BufferSource = ArrayBufferView | ArrayBuffer;
-type URL = import('url').URL;


### PR DESCRIPTION
We weren't including these types so they were becoming `any` for the `encode` options parameter.

What this PR does is:
* Update output folder of libSquoosh types to be `build/libsquoosh/types` to make it resemble its original code location
* Copy codecs types to `build/codecs` folder

So, when `build/libsquoosh/types/codecs.ts` references `../../codecs/webp/enc/webp_node_enc.js` it will have the correct typing.