### PR TITLE
Correct size units for front page example photos

### DIFF
--- a/src/shared/prerendered-app/Intro/index.tsx
+++ b/src/shared/prerendered-app/Intro/index.tsx
@@ -24,28 +24,28 @@ import SlideOnScroll from './SlideOnScroll';
 const demos = [
   {
     description: 'Large photo',
-    size: '2.8mb',
+    size: '2.8 MB',
     filename: 'photo.jpg',
     url: largePhoto,
     iconUrl: largePhotoIcon,
   },
   {
     description: 'Artwork',
-    size: '2.9mb',
+    size: '2.9 MB',
     filename: 'art.jpg',
     url: artwork,
     iconUrl: artworkIcon,
   },
   {
     description: 'Device screen',
-    size: '1.6mb',
+    size: '1.6 MB',
     filename: 'pixel3.png',
     url: deviceScreen,
     iconUrl: deviceScreenIcon,
   },
   {
     description: 'SVG icon',
-    size: '13k',
+    size: '10.7 kB',
     filename: 'squoosh.svg',
     url: logo,
     iconUrl: logoIcon,


### PR DESCRIPTION
Issue linked - #1192 

This adds correct capitialization for size of example photos. Also the size label for the Squoosh logo stated it is 13 kB but really it weighs 10.7 kB

Preview of the changed units 
<img width="873" alt="image" src="https://user-images.githubusercontent.com/67952400/164993714-460236b0-7fe2-4c55-b2c4-477583c833b8.png">
