### PR TITLE
Fix a CLI encConfig error

### DIFF
--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -173,7 +173,7 @@ async function processFiles(files) {
       }
       const encParam = program.opts()[encName];
       const encConfig =
-        encParam.toLowerCase() === 'auto' ? 'auto' : JSON5.parse(encParam);
+        encParam.toString().toLowerCase() === 'auto' ? 'auto' : JSON5.parse(encParam);
       encodeOptions[encName] = encConfig;
     }
     jobsStarted++;


### PR DESCRIPTION
When running the following command

```powershell
squoosh-cli --mozjpeg -d .\out\ .\in\
```

Node.js returns a TypeError:

```log
TypeError: encParam.toLowerCase is not a function
    at Command.processFiles (file:///C:/Users/Admin/AppData/Roaming/npm/node_modules/@squoosh/cli/src/index.js:172:18)
```

> System: Windows 10
> Node.js version: 16.13.1

I have not digged into this issue, but according to a [Stack Overflow discussion on a similar issue in React.js](https://stackoverflow.com/questions/35248292/reactjs-tolowercase-is-not-a-function), here should have a `toString()` method before `toLowercase()` method. I hope I got it correctly.