### PR TITLE
Solves: center image after typing zoom value

### DIFF
--- a/src/client/lazy-app/Compress/Output/custom-els/PinchZoom/index.ts
+++ b/src/client/lazy-app/Compress/Output/custom-els/PinchZoom/index.ts
@@ -173,11 +173,27 @@ export default class PinchZoom extends HTMLElement {
       originY -= currentRect.top;
     }
 
+    //Apply scaling
     this._applyChange({
       allowChangeEvent,
       originX,
       originY,
       scaleDiff: scale / this.scale,
+    });
+
+    //Center image
+    const rectAfterScale = this._positioningEl.getBoundingClientRect();
+    this._applyChange({
+      allowChangeEvent,
+      originX,
+      originY,
+      panX:
+        this.getBoundingClientRect().width / 2 -
+        (rectAfterScale.left + rectAfterScale.width / 2),
+      panY:
+        this.getBoundingClientRect().height / 2 -
+        (rectAfterScale.top + rectAfterScale.height / 2),
+      scaleDiff: 1,
     });
   }
 

--- a/src/client/lazy-app/Compress/Output/index.tsx
+++ b/src/client/lazy-app/Compress/Output/index.tsx
@@ -345,7 +345,7 @@ export default class Output extends Component<Props, State> {
                 ref={linkRef(this, 'scaleInput')}
                 class={style.zoom}
                 value={Math.round(scale * 100)}
-                onInput={this.onScaleInputChanged}
+                onChange={this.onScaleInputChanged}
                 onBlur={this.onScaleInputBlur}
               />
             ) : (


### PR DESCRIPTION
Solves: #1064

Quick demo: 
https://user-images.githubusercontent.com/92958867/177018349-8ecad6a0-0739-4aeb-9d7a-97acce684ae5.mov

Changed the trigger for the scaleTo function so that it is called onChange, rather than onInput. Doing this, the scaling is applied if you press enter, if you use the arrow keys or if you use the UI buttons. I think this option is good, but debouncing could also be implemented as suggested in the issue. Let me know what you think.

Also added a part to recenter the image after scaling it. Before, if you changed the scaling manually by typing and the difference in scaling was big, the image would go out of bounds. Now it recenters every time you scale it by typing or using the UI buttons.

Tested it with different dimensions for the viewport.

Let me know if you have any suggestions or concerns!
