### PR TITLE
Adding node 18.x support

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -20,7 +20,7 @@
         "squoosh-cli": "src/index.js"
       },
       "engines": {
-        "node": " ^12.20.2 || ^14.13.1 || ^16.0.0 "
+        "node": " ^12.20.2 || ^14.13.1 || ^16.0.0 || ^18.0.0 "
       }
     },
     "node_modules/@squoosh/lib": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -20,7 +20,7 @@
   "author": "Google Chrome Developers <chromium-dev@google.com>",
   "license": "Apache-2.0",
   "engines": {
-    "node": " ^12.20.2 || ^14.13.1 || ^16.0.0 "
+    "node": " ^12.20.2 || ^14.13.1 || ^16.0.0 || ^18.0.0 "
   },
   "dependencies": {
     "@squoosh/lib": "^0.4.0",

--- a/libsquoosh/package-lock.json
+++ b/libsquoosh/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@squoosh/lib",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@squoosh/lib",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "wasm-feature-detect": "^1.2.11",
@@ -25,7 +25,7 @@
         "which": "^2.0.2"
       },
       "engines": {
-        "node": " ^12.5.0 || ^14.0.0 || ^16.0.0 "
+        "node": " ^12.5.0 || ^14.0.0 || ^16.0.0 || ^18.0.0 "
       }
     },
     "node_modules/@babel/code-frame": {

--- a/libsquoosh/package.json
+++ b/libsquoosh/package.json
@@ -20,7 +20,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": " ^12.5.0 || ^14.0.0 || ^16.0.0 "
+    "node": " ^12.5.0 || ^14.0.0 || ^16.0.0 || ^18.0.0 "
   },
   "dependencies": {
     "wasm-feature-detect": "^1.2.11",


### PR DESCRIPTION
Fixes #1242 

Node 18 is out, and the engine restrictions currently prevent it working on node 18. This simply adds node 18.x to the supported engines list