### PR TITLE
Fix missing right border on last button

### DIFF
--- a/src/client/lazy-app/Compress/Output/style.css
+++ b/src/client/lazy-app/Compress/Output/style.css
@@ -114,7 +114,7 @@
 .last-button {
   composes: button;
   border-radius: 0 6px 6px 0;
-  border-left-width: 1px;
+  border-right-width: 1px;
 }
 
 .zoom {


### PR DESCRIPTION
### Description

As described in #1272, the last button was missing a right border and instead was given a left border. 
- Resolves #1272 