### PR TITLE
Remove margin in Safari between buttons in button group

### DIFF
--- a/src/client/lazy-app/Compress/Output/style.css
+++ b/src/client/lazy-app/Compress/Output/style.css
@@ -95,6 +95,7 @@
 
 .button {
   color: #fff;
+  margin: 0;
 
   &:hover {
     background: rgba(50, 50, 50, 0.92);


### PR DESCRIPTION
### Description

As described in #1274 , the buttons in Safari have a 2px margin. I think it would look better if this was removed, and align the design with other browsers like Chrome. This PR simply resets the `.button` class to a margin of `0` to ensure uniformity across browsers.

- Resolves #1274 

### Visual (Before)

![safari-margin-big](https://user-images.githubusercontent.com/10838153/185321002-4f7b203d-9fbc-4bec-a2d6-24f37daf04b3.png)

### Visual (After)

![safari-margin-fix](https://user-images.githubusercontent.com/10838153/185327192-d99fff6e-8b77-4327-92b4-27e81966114c.png)
