### PR TITLE
Ensure uniform spacing vertically and horizontally between button groups

### DIFF
--- a/src/client/lazy-app/Compress/Output/style.css
+++ b/src/client/lazy-app/Compress/Output/style.css
@@ -49,6 +49,7 @@
   align-self: center;
   padding: 9px 66px;
   position: relative;
+  gap: 6px;
 
   /* Allow clicks to fall through to the pinch zoom area */
   pointer-events: none;
@@ -68,7 +69,6 @@
   display: flex;
   position: relative;
   z-index: 100;
-  margin: 0 3px;
 }
 
 .button,


### PR DESCRIPTION
### Description

As described in #1276 , the button groups have a horizontal margin but no vertical margin. I think it would look better if a vertical gap/margin was added.

This PR removes the existing `3px` margin from the button groups, and instead adds a `6px` (3px times 2) gap to the `.controls` class (the button groups' parent). The [gap property](https://developer.mozilla.org/docs/Web/CSS/gap) ensures that spacing is uniform whether the button groups are wrapped or not.

- Resolves #1276 

### Visual (No Gap)
![vertical-gap-issue-bottom](https://user-images.githubusercontent.com/10838153/185335838-b2b62509-3d52-4820-8ef2-57ff10480c7c.png)

### Visual (Gap)
![vertical-gap-fix-bottom](https://user-images.githubusercontent.com/10838153/185335927-5ade7c3d-831d-4856-aba3-921d7dbdcefb.png)
![vertical-gap-fix-top](https://user-images.githubusercontent.com/10838153/185335929-48e0484f-6ceb-4c09-93e2-dbc570656564.png)

