### PR TITLE
Added image's display resolution to interface

### DIFF
--- a/src/client/lazy-app/Compress/Output/index.tsx
+++ b/src/client/lazy-app/Compress/Output/index.tsx
@@ -332,6 +332,16 @@ export default class Output extends Component<Props, State> {
           </two-up>
         </div>
         <div class={style.controls}>
+          <div class={style.displayResolution}>
+            {originalImage ? (
+              <span class={style.displayResolutionValue}>
+                <span>{Math.round(scale * originalImage.width)}</span>px×
+                <span>{Math.round(scale * originalImage.height)}</span>px
+              </span>
+            ) : (
+              '...'
+            )}
+          </div>
           <div class={style.buttonGroup}>
             <button class={style.firstButton} onClick={this.zoomOut}>
               <RemoveIcon />

--- a/src/client/lazy-app/Compress/Output/style.css
+++ b/src/client/lazy-app/Compress/Output/style.css
@@ -72,7 +72,8 @@
 }
 
 .button,
-.zoom {
+.zoom,
+.displayResolution {
   display: flex;
   align-items: center;
   box-sizing: border-box;
@@ -141,6 +142,25 @@ input.zoom {
   font-weight: 700;
   text-indent: 3px;
   color: #fff;
+}
+
+.displayResolution {
+  cursor: default;
+  width: 10rem;
+  font: inherit;
+  text-align: center;
+  justify-content: center;
+  border-radius: 6px;
+
+  &:focus {
+    box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.2), 0 0 0 2px #fff;
+  }
+}
+span.displayResolutionValue {
+  color: #939393;
+  line-height: 1.2;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .zoom-value {


### PR DESCRIPTION
Added the image's display resolution to the interface placed beside the zoom controls. The display resolution refers to the CSS pixels the image is currently being viewed at.

The resolution is read-only.

![Display resolution on desktop](https://user-images.githubusercontent.com/8075326/209566477-94be8d7e-3528-4d10-b10f-1e3d427ff503.png)

![Display resolution on desktop](https://user-images.githubusercontent.com/8075326/209566480-5ac5dcb1-c60f-4263-885b-2492607b82f8.png)

![Display resolution on mobile](https://user-images.githubusercontent.com/8075326/209566482-5231933c-f542-4962-b9d0-dfab9954b57c.png)


Closes #1305 