### PR TITLE
Rotate copy-over-buttons correctly

### DIFF
--- a/src/client/lazy-app/Compress/Options/style.css
+++ b/src/client/lazy-app/Compress/Options/style.css
@@ -112,6 +112,9 @@
 .copy-over-button {
   composes: title-button;
 
+  /* Make the filled arrow point towards the other options element */
+  transform: rotate(var(--rotate-copyoverbutton-angle));
+
   svg {
     fill: var(--header-text-color);
   }

--- a/src/client/lazy-app/Compress/style.css
+++ b/src/client/lazy-app/Compress/style.css
@@ -45,9 +45,11 @@
   --hot-theme-color: var(--hot-pink);
   --header-text-color: var(--white);
   --scroller-radius: var(--options-radius) var(--options-radius) 0 0;
+  --rotate-copyoverbutton-angle: 90deg; /* To point down */
 
   @media (min-width: 600px) {
     --scroller-radius: 0 var(--options-radius) var(--options-radius) 0;
+    --rotate-copyoverbutton-angle: 0deg; /* To point right (no change) */
   }
 }
 
@@ -56,9 +58,11 @@
   --hot-theme-color: var(--deep-blue);
   --header-text-color: var(--dark-text);
   --scroller-radius: var(--options-radius) var(--options-radius) 0 0;
+  --rotate-copyoverbutton-angle: -90deg; /* To point up */
 
   @media (min-width: 600px) {
     --scroller-radius: var(--options-radius) 0 0 var(--options-radius);
+    --rotate-copyoverbutton-angle: 180deg; /* To point left */
   }
 }
 


### PR DESCRIPTION
# Minor UI improvement

This PR rotates the `copy-over-button` elements in the correct direction to point towards the other `options` element. <br>It's especially confusing on mobile, where there's nothing on either side of the `options` element so you don't know what the button is supposed to do.

It's only a subtle difference on desktop but the issue still remains (**top right of each `options` element**):

### Comparison (Desktop)

| Before | After |
|---|---|
| ![localhost_8800_ (1)](https://user-images.githubusercontent.com/49340972/222283037-7a3fdab4-d8eb-4ad8-be75-e9c838d31023.png) | ![localhost_8800_editor](https://user-images.githubusercontent.com/49340972/222283065-b054d0c4-8ab6-4f67-8cea-627718f90b05.png) |

### Comparison (Mobile)

| Before | After |
|---|---|
| ![localhost_8800_(Pixel 5)](https://user-images.githubusercontent.com/49340972/222283524-ec5bda19-e94d-4f29-bf89-a12b5bd172aa.png) | ![localhost_8800_(Pixel 5) (1)](https://user-images.githubusercontent.com/49340972/222283556-282e89ec-5a0e-4f17-ba68-bb86b427634e.png) |