### PR TITLE
Better Keyboard A11y + Navigation

### DIFF
--- a/src/client/lazy-app/Compress/Options/Checkbox/style.css
+++ b/src/client/lazy-app/Compress/Options/Checkbox/style.css
@@ -2,6 +2,26 @@
   display: inline-block;
   position: relative;
   --size: 17px;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 200%;
+    height: 200%;
+    background-color: var(--main-theme-color);
+    border-radius: 999px;
+    opacity: 0.25;
+
+    transform: translate(-50%, -50%) scale(0);
+    transition-property: transform;
+    transition-duration: 250ms;
+  }
+
+  &:focus-within::before {
+    transform: translate(-50%, -50%) scale(1);
+  }
 }
 
 .real-checkbox {

--- a/src/client/lazy-app/Compress/Options/Range/custom-els/RangeInput/style.css
+++ b/src/client/lazy-app/Compress/Options/Range/custom-els/RangeInput/style.css
@@ -47,6 +47,10 @@ range-input::before {
   height: 12px;
 }
 
+range-input:focus-within .thumb {
+  outline: white solid 2px;
+}
+
 .thumb-wrapper {
   position: absolute;
   left: 6px;

--- a/src/client/lazy-app/Compress/Options/Toggle/style.css
+++ b/src/client/lazy-app/Compress/Options/Toggle/style.css
@@ -11,6 +11,10 @@
   padding: 3px calc(var(--thumb-size) / 2 + 3px);
 }
 
+.checkbox:focus-within .track {
+  outline: white solid 2px;
+}
+
 .thumb {
   position: relative;
   width: var(--thumb-size);

--- a/src/client/lazy-app/Compress/Options/index.tsx
+++ b/src/client/lazy-app/Compress/Options/index.tsx
@@ -197,6 +197,12 @@ export default class Options extends Component<Props, State> {
                     }
                     title="Import saved side settings"
                     onClick={this.onImportSideSettingsClick}
+                    disabled={
+                      // Disabled if this side's settings haven't been saved
+                      (!this.state.leftSideSettings &&
+                        this.props.index === 0) ||
+                      (!this.state.rightSideSettings && this.props.index === 1)
+                    }
                   >
                     <ImportIcon />
                   </button>

--- a/src/client/lazy-app/Compress/Options/style.css
+++ b/src/client/lazy-app/Compress/Options/style.css
@@ -83,11 +83,11 @@
 }
 
 .text-field {
-  background: var(--white);
-  color: var(--black);
+  background-color: var(--black);
+  color: var(--white);
   font: inherit;
   border: none;
-  padding: 6px 0 6px 10px;
+  padding: 6px 6px 6px 10px;
   width: 100%;
   box-sizing: border-box;
   border-radius: 4px;

--- a/src/client/lazy-app/Compress/Options/style.css
+++ b/src/client/lazy-app/Compress/Options/style.css
@@ -53,6 +53,16 @@
   composes: option-toggle;
   grid-template-columns: auto 1fr;
   gap: 1em;
+
+  border-top: 1px solid #fff4;
+
+  transition-property: background-color;
+  transition-duration: 250ms;
+}
+
+.option-reveal:focus-within,
+.option-reveal:hover {
+  background-color: #fff2;
 }
 
 .option-one-cell {
@@ -117,6 +127,11 @@
 
   svg {
     fill: var(--header-text-color);
+  }
+
+  &:focus {
+    outline: var(--header-text-color) solid 2px;
+    outline-offset: 0.25em;
   }
 }
 

--- a/src/client/lazy-app/Compress/Options/style.css
+++ b/src/client/lazy-app/Compress/Options/style.css
@@ -142,6 +142,11 @@
   svg {
     stroke: var(--header-text-color);
   }
+
+  &:focus {
+    outline: var(--header-text-color) solid 2px;
+    outline-offset: 0.25em;
+  }
 }
 
 .button-opacity {

--- a/src/client/lazy-app/Compress/style.css
+++ b/src/client/lazy-app/Compress/style.css
@@ -113,6 +113,13 @@
 
   & > svg {
     width: 47px;
+    overflow: visible;
+  }
+
+  &:focus .back-blob {
+    stroke: var(--deep-blue);
+    stroke-width: 5px;
+    animation: strokePulse 500ms ease forwards;
   }
 
   @media (min-width: 600px) {
@@ -121,6 +128,15 @@
     & > svg {
       width: 58px;
     }
+  }
+}
+
+@keyframes strokePulse {
+  from {
+    stroke-width: 8px;
+  }
+  to {
+    stroke-width: 5px;
   }
 }
 


### PR DESCRIPTION
Keyboard accessibility is super important, and not just for the visually impaired. It's common practice to `TAB` through a website when your mouse is faulty and/or you can't be bothered to reach for it. The options components  aren't very keyboard-accessible; this PR aims to change that.

Changes include:
* Making all input types react to keyboard focus
* Minor design improvements in this scope

## Visual Comparison

In both before and after I `TAB` to the `Advanced Settings` expander, and then `TAB` to the end. If it feels like I'm not doing anything in the _before changes_ video... well, that's the issue. I also try to make the checkboxes feel like Material UI, but I can only get so far without a complete overhaul.

[Before changes - Little to no focus effects](https://imgur.com/a/eXLFNsR)
[After changes - 100% support for keyboard navigation](https://imgur.com/a/6TFwupl)
