### PR TITLE
Feat : Original image name (file name)

### DIFF
--- a/src/client/lazy-app/Compress/Options/index.tsx
+++ b/src/client/lazy-app/Compress/Options/index.tsx
@@ -190,7 +190,9 @@ export default class Options extends Component<Props, State> {
               onChange={this.onEncoderTypeChange}
               large
             >
-              <option value="identity">Original Image</option>
+              <option value="identity">{`Original Image ${
+                this.props.source ? `(${this.props.source.file.name})` : ''
+              }`}</option>
               {Object.entries(supportedEncoderMap).map(([type, encoder]) => (
                 <option value={type}>{encoder.meta.label}</option>
               ))}

--- a/src/client/lazy-app/Compress/index.tsx
+++ b/src/client/lazy-app/Compress/index.tsx
@@ -885,6 +885,9 @@ export default class Compress extends Component<Props, State> {
             />
           </svg>
         </button>
+        {!mobileView && this.state.source ? (
+          <span class={style.filename}>{this.state.source.file.name}</span>
+        ) : null}
         {mobileView ? (
           <div class={style.options}>
             <multi-panel class={style.multiPanel} open-one-only>

--- a/src/client/lazy-app/Compress/index.tsx
+++ b/src/client/lazy-app/Compress/index.tsx
@@ -842,7 +842,7 @@ export default class Compress extends Component<Props, State> {
         typeLabel={
           side.latestSettings.encoderState
             ? encoderMap[side.latestSettings.encoderState.type].meta.label
-            : 'Original Image'
+            : `${side.file ? `${side.file.name}` : 'Original Image'}`
         }
       />
     ));

--- a/src/client/lazy-app/Compress/style.css
+++ b/src/client/lazy-app/Compress/style.css
@@ -111,6 +111,10 @@
   justify-self: start;
   align-self: start;
 
+  &:hover .back-blob {
+    opacity: 1;
+  }
+
   & > svg {
     width: 47px;
   }
@@ -127,8 +131,34 @@
 .back-blob {
   fill: var(--hot-pink);
   opacity: 0.77;
+  transition: opacity 500ms ease;
 }
 
 .back-x {
   fill: var(--white);
+}
+
+.filename {
+  composes: unbutton from global;
+  position: relative;
+  grid-area: header;
+  margin: 9px;
+  justify-self: end;
+  align-self: start;
+
+  background-color: var(--hot-pink);
+  color: #fff;
+
+  padding: 10px 20px;
+  font-weight: bold;
+  font-size: 1.1rem;
+
+  pointer-events: none;
+
+  border-radius: 9999px;
+
+  @media (min-width: 600px) {
+    margin: 14px;
+    font-size: 1.4rem;
+  }
 }


### PR DESCRIPTION
Inside Compress tab Original image string
will be appended by file name.

In mobile view due to space constrain there
will be only in that dropdown <file name>

Before Desktop

<img width="1439" alt="Screenshot 2023-04-02 at 9 34 54 PM" src="https://user-images.githubusercontent.com/48324810/229364980-41baf269-2dca-4ecc-bd76-12a5312c4f27.png">


After Desktop

<img width="1439" alt="Screenshot 2023-04-02 at 9 32 40 PM" src="https://user-images.githubusercontent.com/48324810/229364944-ea4b314c-3f30-441c-8ec4-e3d26ee361f9.png">


Similarly,

Before mobile

<img width="344" alt="Screenshot 2023-04-02 at 9 40 07 PM" src="https://user-images.githubusercontent.com/48324810/229365120-48d950d8-c8ed-4948-b02c-7d03daf1c205.png">

After mobile

<img width="344" alt="Screenshot 2023-04-02 at 9 41 01 PM" src="https://user-images.githubusercontent.com/48324810/229365137-16274ddb-7aa9-490a-8fdc-bb9899681dd9.png">


Also added a file title at the top right corner

<img width="1439" alt="Screenshot 2023-04-02 at 10 07 25 PM" src="https://user-images.githubusercontent.com/48324810/229366524-eb5a47de-7418-4e3b-bea3-5a0cbc8402af.png">

I hope it looks good and it won't be available for mobileview
