### PR TITLE
Feat : Original image name (file name)

### DIFF
--- a/src/client/lazy-app/Compress/Options/index.tsx
+++ b/src/client/lazy-app/Compress/Options/index.tsx
@@ -190,7 +190,9 @@ export default class Options extends Component<Props, State> {
               onChange={this.onEncoderTypeChange}
               large
             >
-              <option value="identity">Original Image</option>
+              <option value="identity">{`Original Image ${
+                this.props.source ? `(${this.props.source.file.name})` : ''
+              }`}</option>
               {Object.entries(supportedEncoderMap).map(([type, encoder]) => (
                 <option value={type}>{encoder.meta.label}</option>
               ))}

--- a/src/client/lazy-app/Compress/index.tsx
+++ b/src/client/lazy-app/Compress/index.tsx
@@ -842,7 +842,7 @@ export default class Compress extends Component<Props, State> {
         typeLabel={
           side.latestSettings.encoderState
             ? encoderMap[side.latestSettings.encoderState.type].meta.label
-            : 'Original Image'
+            : `${side.file ? `${side.file.name}` : 'Original Image'}`
         }
       />
     ));


### PR DESCRIPTION
Inside Compress tab Original image string
will be appended by file name.

In mobile view due to space constrain there
will be only in that dropdown

Before Desktop

<img width="1439" alt="Screenshot 2023-04-02 at 9 34 54 PM" src="https://user-images.githubusercontent.com/48324810/229367356-13b852c1-a09a-49f3-9350-7b67f2374d85.png">


After Desktop

<img width="1439" alt="Screenshot 2023-04-02 at 9 32 40 PM" src="https://user-images.githubusercontent.com/48324810/229367362-392fa850-ff23-4497-863d-efb14095dfca.png">


Similarly,

Before mobile

<img width="344" alt="Screenshot 2023-04-02 at 9 40 07 PM" src="https://user-images.githubusercontent.com/48324810/229367334-9757fe51-ea76-436f-9467-f756051bdc58.png">


After mobile

<img width="344" alt="Screenshot 2023-04-02 at 9 41 01 PM" src="https://user-images.githubusercontent.com/48324810/229367327-cd34f701-fab0-450e-b9cf-409b6f3c75de.png">
