### PR TITLE
Feat : Showing source file name

### DIFF
--- a/src/client/lazy-app/Compress/index.tsx
+++ b/src/client/lazy-app/Compress/index.tsx
@@ -885,6 +885,9 @@ export default class Compress extends Component<Props, State> {
             />
           </svg>
         </button>
+        {!mobileView && this.state.source ? (
+          <span class={style.filename}>{this.state.source.file.name}</span>
+        ) : null}
         {mobileView ? (
           <div class={style.options}>
             <multi-panel class={style.multiPanel} open-one-only>

--- a/src/client/lazy-app/Compress/style.css
+++ b/src/client/lazy-app/Compress/style.css
@@ -111,6 +111,10 @@
   justify-self: start;
   align-self: start;
 
+  &:hover .back-blob {
+    opacity: 1;
+  }
+
   & > svg {
     width: 47px;
   }
@@ -127,8 +131,34 @@
 .back-blob {
   fill: var(--hot-pink);
   opacity: 0.77;
+  transition: opacity 500ms ease;
 }
 
 .back-x {
   fill: var(--white);
+}
+
+.filename {
+  composes: unbutton from global;
+  position: relative;
+  grid-area: header;
+  margin: 9px;
+  justify-self: end;
+  align-self: start;
+
+  background-color: var(--hot-pink);
+  color: #fff;
+
+  padding: 10px 20px;
+  font-weight: bold;
+  font-size: 1.1rem;
+
+  pointer-events: none;
+
+  border-radius: 9999px;
+
+  @media (min-width: 600px) {
+    margin: 14px;
+    font-size: 1.4rem;
+  }
 }


### PR DESCRIPTION
There will be file name shown in pink theme
at top right corner in desktop mode

added a file title at the top right corner

<img width="1439" alt="Screenshot 2023-04-02 at 10 07 25 PM" src="https://user-images.githubusercontent.com/48324810/229367317-2c1d7f4d-08e4-459a-a5c1-2a75c361f272.png">

I hope it looks good and it won't be available for mobileview