### PR TITLE
implemented scrolling shadows

### DIFF
--- a/src/client/lazy-app/Compress/Options/style.css
+++ b/src/client/lazy-app/Compress/Options/style.css
@@ -3,6 +3,32 @@
   border-radius: var(--scroller-radius);
   overflow: hidden;
 
+  /* Visualize that the menu is scrollable */
+  background: linear-gradient(var(--off-black) 30%, rgba(255, 255, 255, 0)),
+    linear-gradient(rgba(255, 255, 255, 0), var(--off-black) 70%) 0 100%,
+    radial-gradient(50% 0, farthest-side, var(--light-gray), rgba(0, 0, 0, 0)),
+    radial-gradient(
+        50% 100%,
+        farthest-side,
+        var(--light-gray),
+        rgba(0, 0, 0, 0)
+      )
+      0 100%;
+  background: linear-gradient(var(--off-black) 30%, rgba(255, 255, 255, 0)),
+    linear-gradient(rgba(255, 255, 255, 0), var(--off-black) 70%) 0 100%,
+    radial-gradient(farthest-side at 50% 0, var(--light-gray), rgba(0, 0, 0, 0)),
+    radial-gradient(
+        farthest-side at 50% 100%,
+        var(--light-gray),
+        rgba(0, 0, 0, 0)
+      )
+      0 100%;
+  background-repeat: no-repeat;
+  background-color: var(--off-black);
+  background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+  /* Opera doesn't support this in the shorthand */
+  background-attachment: local, local, scroll, scroll;
+
   /* At smaller widths, the multi-panel handles the scrolling */
   @media (min-width: 600px) {
     overflow-x: hidden;
@@ -69,7 +95,7 @@
 }
 
 .options-section {
-  background: var(--off-black);
+  /* background: var(--off-black); */
 }
 
 .text-field {


### PR DESCRIPTION
As @argyleink suggested in issue #218 I tried to implement the scrolling shadows using a gradient background.

Like the one explained here: https://lea.verou.me/2012/04/background-attachment-local

A dark shadow is hardly noticeable so I went for something brighter.

I removed the `options-section` background to make the scrolling shadows visible. It doesn't look great, since the other components are obviously displayed on top of the scrolling shadows.

<img width="317" alt="Bildschirmfoto 2023-04-08 um 17 05 42" src="https://user-images.githubusercontent.com/53651857/230728518-bdb075ea-b715-4c42-beaf-85ec79f4adee.png">

Do you have any ideas on how to fix that? Or is this acceptable?

closes #218 