### PR TITLE
added snack bar inside noscript element

### DIFF
--- a/src/shared/custom-els/snack-bar/styles.css
+++ b/src/shared/custom-els/snack-bar/styles.css
@@ -62,7 +62,7 @@ snack-bar {
   position: relative;
   flex: 0 1 auto;
   padding: 8px;
-  height: 36px;
+  height: 100%;
   margin: auto 8px auto -8px;
   min-width: 5em;
   background: none;
@@ -78,6 +78,7 @@ snack-bar {
   overflow: hidden;
   transition: background-color 200ms ease;
   outline: none;
+  text-decoration: none;
 }
 .button:hover {
   background-color: rgba(0, 0, 0, 0.15);

--- a/src/static-build/pages/index/index.tsx
+++ b/src/static-build/pages/index/index.tsx
@@ -89,8 +89,8 @@ const Index: FunctionalComponent<Props> = () => (
               aria-hidden="false"
             >
               <div class={snackbarStyle.text}>
-                Initialization error: JavaScript is disabled in your browser but
-                it is required for this site to work.
+                Initialization error: This site requires JavaScript, which is
+                disabled in your browser.
               </div>
               <a class={snackbarStyle.button} href="/">
                 reload

--- a/src/static-build/pages/index/index.tsx
+++ b/src/static-build/pages/index/index.tsx
@@ -89,7 +89,8 @@ const Index: FunctionalComponent<Props> = () => (
               aria-hidden="false"
             >
               <div class={snackbarStyle.text}>
-                Initialization error: JavaScript is disabled
+                Initialization error: JavaScript is disabled in your browser but
+                it is required for this site to work.
               </div>
               <a class={snackbarStyle.button} href="/">
                 reload

--- a/src/static-build/pages/index/index.tsx
+++ b/src/static-build/pages/index/index.tsx
@@ -19,6 +19,8 @@ import favicon from 'url:static-build/assets/favicon.ico';
 import ogImage from 'url:static-build/assets/icon-large-maskable.png';
 import { escapeStyleScriptContent, siteOrigin } from 'static-build/utils';
 import Intro from 'shared/prerendered-app/Intro';
+import snackbarCss from 'css:../../../shared/custom-els/snack-bar/styles.css';
+import * as snackbarStyle from '../../../shared/custom-els/snack-bar/styles.css';
 
 interface Props {}
 
@@ -73,6 +75,28 @@ const Index: FunctionalComponent<Props> = () => (
     <body>
       <div id="app">
         <Intro />
+        <noscript>
+          <style
+            dangerouslySetInnerHTML={{
+              __html: escapeStyleScriptContent(snackbarCss),
+            }}
+          />
+          <snack-bar>
+            <div
+              class={snackbarStyle.snackbar}
+              aria-live="assertive"
+              aria-atomic="true"
+              aria-hidden="false"
+            >
+              <div class={snackbarStyle.text}>
+                Initialization error: JavaScript is disabled
+              </div>
+              <a class={snackbarStyle.button} href="/">
+                reload
+              </a>
+            </div>
+          </snack-bar>
+        </noscript>
       </div>
       <script
         dangerouslySetInnerHTML={{


### PR DESCRIPTION
Display a snackbar when javascript is disabled.
Snackbar button reloads the page (as an anchor tag).

Desktop:
<img width="512" alt="Screenshot Desktop" src="https://user-images.githubusercontent.com/53651857/230732500-0b991e55-31b5-4e82-ac9c-c546c852337b.png">

Mobile:
<img width="256" alt="Screenshot Mobile" src="https://user-images.githubusercontent.com/53651857/230732520-b9105936-ccb7-4739-9393-527e0b867db5.png">

closes #593 