### PR TITLE
Display codec versions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ To develop for Squoosh:
    npm run dev
    ```
 
+# Codecs
+
+1. AVIF
+   - [libavif - v0.11.1+](https://github.com/AOMediaCodec/libavif/commit/647c3c208cf152395d777c1bf7240d2ecf7df5a9)
+   - [AOM Library - v3.6.0](https://aomedia.googlesource.com/aom/+/refs/tags/v3.6.0)
+1. Browser JPEG
+   - Uses your browser's native JPEG capabilities
+1. Browser PNG
+   - Uses your browser's native PNG capabilities
+1. JPEGXL
+   - [libjxl - v0.6.1+](https://github.com/libjxl/libjxl/commit/9f544641ec83f6abd9da598bdd08178ee8a003e0)
+1. MozJPEG
+   - [mozjpeg - v3.3.1](https://github.com/mozilla/mozjpeg/releases/v3.3.1)
+1. OxiPNG
+   - [oxipng - v3.0.0](https://github.com/shssoichiro/oxipng/releases/v3.0.0)
+1. WebP
+   - [webmproject/libwebp - v1.1.0+](https://github.com/webmproject/libwebp/commit/d2e245ea9e959a5a79e1db0ed2085206947e98f2)
+1. WebP v2 (experimental)
+   - [chromium/libwebp2 - Jan 7, 2021](https://chromium.googlesource.com/codecs/libwebp2/+/413df7caeca5013fa9a51401660f7efd8572e0ae)
+
 # Contributing
 
 Squoosh is an open-source project that appreciates all community involvement. To contribute to the project, follow the [contribute guide](/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -33,25 +33,17 @@ To develop for Squoosh:
 
 # Codecs
 
-1. AVIF
-   - [libavif - v1.0.1](https://github.com/AOMediaCodec/libavif/releases/tag/v1.0.1)
-   - [AOM Library - v3.7.0](https://aomedia.googlesource.com/aom/+/refs/tags/v3.7.0)
-1. Browser JPEG
-   - Uses your browser's native JPEG capabilities
-1. Browser PNG
-   - Uses your browser's native PNG capabilities
-1. JPEGXL
-   - [libjxl - v0.6.1+](https://github.com/libjxl/libjxl/commit/9f544641ec83f6abd9da598bdd08178ee8a003e0)
-1. MozJPEG
-   - [mozjpeg - v3.3.1](https://github.com/mozilla/mozjpeg/releases/v3.3.1)
-1. OxiPNG
-   - [oxipng - v3.0.0](https://github.com/shssoichiro/oxipng/releases/v3.0.0)
-1. QOI
-   - [phoboslab/qoi - Sep 11, 2023](https://github.com/phoboslab/qoi/commit/8d35d93cdca85d2868246c2a8a80a1e2c16ba2a8)
-1. WebP
-   - [webmproject/libwebp - v1.1.0+](https://github.com/webmproject/libwebp/commit/d2e245ea9e959a5a79e1db0ed2085206947e98f2)
-1. WebP v2 (experimental)
-   - [chromium/libwebp2 - Jan 7, 2021](https://chromium.googlesource.com/codecs/libwebp2/+/413df7caeca5013fa9a51401660f7efd8572e0ae)
+|Codec|Version|
+|---|---|
+|AVIF|[libavif - v1.0.1](https://github.com/AOMediaCodec/libavif/releases/tag/v1.0.1)<br>[AOM Library - v3.7.0](https://aomedia.googlesource.com/aom/+/refs/tags/v3.7.0)|
+|Browser JPEG|Uses your browser's native JPEG capabilities|
+|Browser PNG|Uses your browser's native PNG capabilities|
+|JPEGXL|[libjxl - v0.6.1+](https://github.com/libjxl/libjxl/commit/9f544641ec83f6abd9da598bdd08178ee8a003e0)|
+|MozJPEG|[mozjpeg - v3.3.1](https://github.com/mozilla/mozjpeg/releases/v3.3.1)|
+|OxiPNG|[oxipng - v3.0.0](https://github.com/shssoichiro/oxipng/releases/v3.0.0)|
+|QOI|[phoboslab/qoi - Sep 11, 2023](https://github.com/phoboslab/qoi/commit/8d35d93cdca85d2868246c2a8a80a1e2c16ba2a8)|
+|WebP|[webmproject/libwebp - v1.1.0+](https://github.com/webmproject/libwebp/commit/d2e245ea9e959a5a79e1db0ed2085206947e98f2)|
+|WebP v2 (experimental)|[chromium/libwebp2 - Jan 7, 2021](https://chromium.googlesource.com/codecs/libwebp2/+/413df7caeca5013fa9a51401660f7efd8572e0ae)|
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ To develop for Squoosh:
    - [mozjpeg - v3.3.1](https://github.com/mozilla/mozjpeg/releases/v3.3.1)
 1. OxiPNG
    - [oxipng - v3.0.0](https://github.com/shssoichiro/oxipng/releases/v3.0.0)
+1. QOI
+   - [phoboslab/qoi - Sep 11, 2023](https://github.com/phoboslab/qoi/commit/8d35d93cdca85d2868246c2a8a80a1e2c16ba2a8)
 1. WebP
    - [webmproject/libwebp - v1.1.0+](https://github.com/webmproject/libwebp/commit/d2e245ea9e959a5a79e1db0ed2085206947e98f2)
 1. WebP v2 (experimental)

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ To develop for Squoosh:
 # Codecs
 
 1. AVIF
-   - [libavif - v0.11.1+](https://github.com/AOMediaCodec/libavif/commit/647c3c208cf152395d777c1bf7240d2ecf7df5a9)
-   - [AOM Library - v3.6.0](https://aomedia.googlesource.com/aom/+/refs/tags/v3.6.0)
+   - [libavif - v1.0.1](https://github.com/AOMediaCodec/libavif/releases/tag/v1.0.1)
+   - [AOM Library - v3.7.0](https://aomedia.googlesource.com/aom/+/refs/tags/v3.7.0)
 1. Browser JPEG
    - Uses your browser's native JPEG capabilities
 1. Browser PNG


### PR DESCRIPTION
Adds a 'Codecs' section to the README with the version and source URL for each codec.

Going through each codec's Makefile/README to figure out the implemented version isn't terribly fun, and now you won't have to.
Some codecs are built on commits in-between releases, so I added a `+` after the previous version. `libwebp2` doesn't have any releases, so I kept just the commit date.