### PR TITLE
Fix #1394 for Windows support

### DIFF
--- a/lib/css-plugin.js
+++ b/lib/css-plugin.js
@@ -20,6 +20,7 @@ import {
   normalize as nomalizePath,
   sep as pathSep,
   posix,
+  join as nodeJoin,
 } from 'path';
 
 import postcss from 'postcss';
@@ -30,6 +31,7 @@ import postCSSSimpleVars from 'postcss-simple-vars';
 import cssNano from 'cssnano';
 import camelCase from 'lodash.camelcase';
 import glob from 'glob';
+import { initialCssModule } from './initial-css-plugin';
 
 const globP = promisify(glob);
 
@@ -152,7 +154,16 @@ export default function () {
 
       if (!prefix) return;
 
-      const resolved = await this.resolve(id.slice(prefix.length), importer);
+      let resolved = null;
+      if (importer === initialCssModule) {
+        // Resolve the initial CSS differently
+        const cssPath = id.slice(prefix.length); // "shared/prerendered-app/path/to/file.css"
+        const absolutePath = nodeJoin(process.cwd(), 'src', cssPath); // absolute path
+        resolved = await this.resolve(absolutePath);
+      } else {
+        // Resolve normally
+        resolved = await this.resolve(id.slice(prefix.length), importer);
+      }
       if (!resolved) throw Error(`Couldn't resolve ${id} from ${importer}`);
 
       return prefix + resolved.id;

--- a/lib/initial-css-plugin.js
+++ b/lib/initial-css-plugin.js
@@ -19,7 +19,7 @@ import glob from 'glob';
 const globP = promisify(glob);
 
 const moduleId = 'initial-css:';
-const initialCssModule = '\0initialCss';
+export const initialCssModule = '\0initialCss';
 
 export default function initialCssPlugin() {
   return {


### PR DESCRIPTION
* Resolves the "initial" CSS modules differently so that Windows users don't get a posix path
* Uses`initialCssModule` from initial-css-plugin to identify these modules