### PR TITLE
ci: bump workflow actions to latest versions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,11 +12,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v2
-    - id: nvmrc
-      uses: browniebroke/read-nvmrc-action@v1
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
-        node-version: '${{ steps.nvmrc.outputs.node_version }}'
+        node-version: 14
     - run: npm ci
     - run: npm run build


### PR DESCRIPTION
This PR bumps GitHub action workflows to their latest versions, thus avoiding deprecation warnings as seen [here](https://github.com/GoogleChromeLabs/squoosh/actions/runs/7769713700).
Also deprecated action `browniebroke/read-nvmrc-action` is removed, it is not needed any more.