### PR TITLE
refactor: remove duplicate code in url-plugin.js

### DIFF
--- a/lib/url-plugin.js
+++ b/lib/url-plugin.js
@@ -40,11 +40,6 @@ export default function urlPlugin(opts) {
 
       if (buffers.length === 0) return;
 
-      for (const moduleId of Object.keys(info.modules)) {
-        const buffer = assetIdToSourceBuffer.get(moduleId);
-        if (buffer) buffers.push(buffer);
-      }
-
       const combinedBuffer =
         buffers.length === 1 ? buffers[0] : Buffer.concat(buffers);
 


### PR DESCRIPTION
Remove redundant loop in augmentChunkHash function. The second loop (lines 43-46) duplicates the buffer collection already done by the first loop (lines 37-39), causing unnecessary duplication in the buffers array.