### PR TITLE
Remove reference to non-existent FAQ from bug report template (issue #1449)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -5,8 +5,7 @@ labels:
 
 ---
 
-**Before you start**
-Please take a look at the [FAQ](https://github.com/GoogleChromeLabs/squoosh/wiki/FAQ) as well as the already opened issues! If nothing fits your problem, go ahead and fill out the following template:
+
 
 **Describe the bug**
 A clear and concise description of what the bug is.


### PR DESCRIPTION
Removed the line referencing the FAQ page in the bug report template, as the page no longer exists. This fixes issue #1449 and prevents users from being directed to a broken link when opening a bug report.