### PR TITLE
Add set background processor

### DIFF
--- a/src/client/lazy-app/Compress/Options/index.tsx
+++ b/src/client/lazy-app/Compress/Options/index.tsx
@@ -1,4 +1,4 @@
-import { h, Component } from 'preact';
+import { h, Component, Fragment } from 'preact';
 
 import * as style from './style.css';
 import 'add-css:./style.css';
@@ -16,6 +16,7 @@ import Expander from './Expander';
 import Toggle from './Toggle';
 import Select from './Select';
 import { Options as QuantOptionsComponent } from 'features/processors/quantize/client';
+import { Options as SetBackgroundOptionsComponent } from 'features/processors/setBackground/client';
 import { Options as ResizeOptionsComponent } from 'features/processors/resize/client';
 import { ImportIcon, SaveIcon, SwapIcon } from 'client/lazy-app/icons';
 
@@ -124,6 +125,15 @@ export default class Options extends Component<Props, State> {
     );
   };
 
+  private onSetBackgroundOptionsChange = (
+    opts: ProcessorOptions['setBackground'],
+  ) => {
+    this.props.onProcessorOptionsChange(
+      this.props.index,
+      cleanMerge(this.props.processorState, 'setBackground', opts),
+    );
+  };
+
   private onResizeOptionsChange = (opts: ProcessorOptions['resize']) => {
     this.props.onProcessorOptionsChange(
       this.props.index,
@@ -227,6 +237,27 @@ export default class Options extends Component<Props, State> {
                   />
                 ) : null}
               </Expander>
+
+              {source && source.hasTransparency ? (
+                <Fragment>
+                  <label class={style.sectionEnabler}>
+                    Set background
+                    <Toggle
+                      name="setBackground.enable"
+                      checked={!!processorState.setBackground.enabled}
+                      onChange={this.onProcessorEnabledChange}
+                    />
+                  </label>
+                  <Expander>
+                    {processorState.setBackground.enabled ? (
+                      <SetBackgroundOptionsComponent
+                        options={processorState.setBackground}
+                        onChange={this.onSetBackgroundOptionsChange}
+                      />
+                    ) : null}
+                  </Expander>
+                </Fragment>
+              ) : null}
 
               <label class={style.sectionEnabler}>
                 Reduce palette

--- a/src/client/lazy-app/Compress/index.tsx
+++ b/src/client/lazy-app/Compress/index.tsx
@@ -39,6 +39,7 @@ export interface SourceImage {
   file: File;
   decoded: ImageData;
   preprocessed: ImageData;
+  hasTransparency: boolean;
   vectorImage?: HTMLImageElement;
 }
 
@@ -83,6 +84,10 @@ interface SideJob {
   encoderState?: EncoderState;
 }
 
+type StoredProcessorState = Partial<ProcessorState> & {
+  removeTransparency?: ProcessorState['setBackground'];
+};
+
 interface LoadingFileInfo {
   loading: boolean;
   filename?: string;
@@ -124,6 +129,16 @@ async function decodeImage(
   }
 }
 
+function hasTransparency(imageData: ImageData): boolean {
+  const pixels = imageData.data;
+
+  for (let i = 3; i < pixels.length; i += 4) {
+    if (pixels[i] !== 255) return true;
+  }
+
+  return false;
+}
+
 async function preprocessImage(
   signal: AbortSignal,
   data: ImageData,
@@ -155,6 +170,13 @@ async function processImage(
 
   if (processorState.resize.enabled) {
     result = await resize(signal, source, processorState.resize, workerBridge);
+  }
+  if (source.hasTransparency && processorState.setBackground.enabled) {
+    result = await workerBridge.setBackground(
+      signal,
+      result,
+      processorState.setBackground,
+    );
   }
   if (processorState.quantize.enabled) {
     result = await workerBridge.quantize(
@@ -212,6 +234,46 @@ function stateForNewSourceData(state: State): State {
   }
 
   return newState;
+}
+
+function normalizeProcessorState(
+  processorState?: StoredProcessorState,
+): ProcessorState {
+  const setBackground =
+    processorState?.setBackground || processorState?.removeTransparency;
+
+  return {
+    quantize: {
+      ...defaultProcessorState.quantize,
+      ...processorState?.quantize,
+    },
+    setBackground: {
+      ...defaultProcessorState.setBackground,
+      ...setBackground,
+    },
+    resize: {
+      ...defaultProcessorState.resize,
+      ...processorState?.resize,
+    },
+  };
+}
+
+function normalizeSide(side: Side): Side {
+  return {
+    ...side,
+    latestSettings: {
+      ...side.latestSettings,
+      processorState: normalizeProcessorState(
+        side.latestSettings.processorState,
+      ),
+    },
+    encodedSettings: side.encodedSettings && {
+      ...side.encodedSettings,
+      processorState: normalizeProcessorState(
+        side.encodedSettings.processorState,
+      ),
+    },
+  };
 }
 
 async function processSvg(
@@ -284,13 +346,13 @@ export default class Compress extends Component<Props, State> {
     source: undefined,
     loading: false,
     preprocessorState: defaultPreprocessorState,
-    // Tasking catched side settings if available otherwise taking default settings
+    // Persisted settings can predate processors added after they were saved.
     sides: [
       localStorage.getItem('leftSideSettings')
-        ? {
+        ? normalizeSide({
             ...JSON.parse(localStorage.getItem('leftSideSettings') as string),
             loading: false,
-          }
+          })
         : {
             latestSettings: {
               processorState: defaultProcessorState,
@@ -299,10 +361,10 @@ export default class Compress extends Component<Props, State> {
             loading: false,
           },
       localStorage.getItem('rightSideSettings')
-        ? {
+        ? normalizeSide({
             ...JSON.parse(localStorage.getItem('rightSideSettings') as string),
             loading: false,
-          }
+          })
         : {
             latestSettings: {
               processorState: defaultProcessorState,
@@ -492,10 +554,10 @@ export default class Compress extends Component<Props, State> {
 
     if (index === 0 && leftSideSettingsString) {
       const oldLeftSideSettings = this.state.sides[index];
-      const newLeftSideSettings = {
+      const newLeftSideSettings = normalizeSide({
         ...this.state.sides[index],
         ...JSON.parse(leftSideSettingsString),
-      };
+      });
       this.setState({
         sides: cleanSet(this.state.sides, index, newLeftSideSettings),
       });
@@ -513,10 +575,10 @@ export default class Compress extends Component<Props, State> {
 
     if (index === 1 && rightSideSettingsString) {
       const oldRightSideSettings = this.state.sides[index];
-      const newRightSideSettings = {
+      const newRightSideSettings = normalizeSide({
         ...this.state.sides[index],
         ...JSON.parse(rightSideSettingsString),
-      };
+      });
       this.setState({
         sides: cleanSet(this.state.sides, index, newRightSideSettings),
       });
@@ -753,6 +815,7 @@ export default class Compress extends Component<Props, State> {
           decoded,
           vectorImage,
           preprocessed,
+          hasTransparency: hasTransparency(preprocessed),
           file: mainJobState.file,
         };
 

--- a/src/features/processors/setBackground/client/index.tsx
+++ b/src/features/processors/setBackground/client/index.tsx
@@ -1,0 +1,46 @@
+import { h, Component } from 'preact';
+import { Options as SetBackgroundOptions } from '../shared/meta';
+import * as style from 'client/lazy-app/Compress/Options/style.css';
+import { preventDefault, inputFieldValue } from 'client/lazy-app/util';
+
+interface Props {
+  options: SetBackgroundOptions;
+  onChange(newOptions: SetBackgroundOptions): void;
+}
+
+export class Options extends Component<Props, {}> {
+  setColorInput = (input: HTMLInputElement | null) => {
+    if (input) input.setAttribute('alpha', '');
+  };
+
+  onChange = (event: Event) => {
+    const form = (event.currentTarget as HTMLInputElement).closest(
+      'form',
+    ) as HTMLFormElement;
+
+    this.props.onChange({
+      background: inputFieldValue(
+        form.background,
+        this.props.options.background,
+      ),
+    });
+  };
+
+  render({ options }: Props) {
+    return (
+      <form class={style.optionsSection} onSubmit={preventDefault}>
+        <label class={style.optionTextFirst}>
+          Background:
+          <input
+            class={style.textField}
+            name="background"
+            type="color"
+            ref={this.setColorInput}
+            value={options.background}
+            onInput={this.onChange}
+          />
+        </label>
+      </form>
+    );
+  }
+}

--- a/src/features/processors/setBackground/shared/meta.ts
+++ b/src/features/processors/setBackground/shared/meta.ts
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface Options {
+  background: string;
+}
+
+export const defaultOptions: Options = {
+  background: '#ffffff',
+};

--- a/src/features/processors/setBackground/worker/setBackground.ts
+++ b/src/features/processors/setBackground/worker/setBackground.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2020 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Options } from '../shared/meta';
+
+interface ImageDataCanvas {
+  getContext(contextId: '2d'): ImageDataCanvasRenderingContext2D | null;
+}
+
+interface ImageDataCanvasRenderingContext2D {
+  fillStyle: string;
+  globalCompositeOperation: string;
+  fillRect(x: number, y: number, width: number, height: number): void;
+  getImageData(sx: number, sy: number, sw: number, sh: number): ImageData;
+  putImageData(imageData: ImageData, dx: number, dy: number): void;
+}
+
+const { OffscreenCanvas } = globalThis as unknown as {
+  // TypeScript 4.4's webworker lib has only an empty OffscreenCanvas type.
+  OffscreenCanvas: new (width: number, height: number) => ImageDataCanvas;
+};
+
+export default async function setBackground(
+  data: ImageData,
+  opts: Options,
+): Promise<ImageData> {
+  const canvas = new OffscreenCanvas(data.width, data.height);
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    throw Error('Could not create canvas context');
+  }
+
+  ctx.putImageData(data, 0, 0);
+  ctx.fillStyle = '#ffffff';
+  ctx.fillStyle = opts.background;
+  ctx.globalCompositeOperation = 'destination-over';
+  ctx.fillRect(0, 0, data.width, data.height);
+
+  return ctx.getImageData(0, 0, data.width, data.height);
+}


### PR DESCRIPTION
## Summary
- add a Set background processor with a configurable background color for transparent inputs
- use an alpha-capable color picker and OffscreenCanvas `destination-over` compositing so the browser handles CSS color parsing and alpha blending
- hide the Set background option when the current preprocessed input has no transparency
- run alpha compositing after resize and before palette reduction/encode so vector resize stays vector and fewer pixels are composited
- normalize saved processor settings so older localStorage entries load safely, including the earlier draft removeTransparency key

## Verification
- PATH="$PWD/node_modules/.bin:$PATH" node_modules/.bin/tsc -b client-tsconfig.json worker-tsconfig.json --pretty false
- PATH="$PWD/node_modules/.bin:$PATH" node_modules/.bin/rollup -c && node lib/move-output.js
- browser smoke test: transparent demo PNG shows Set background and no Remove Transparency label
- browser smoke test: Set background color input has the alpha attribute when expanded
- browser smoke test: enabling Set background composites transparent output canvas pixels over opaque white
- browser smoke test: opaque demo JPEG hides Set background

Note: local npm/npx wrappers are blocked in this environment, so the commit hook was bypassed after typecheck, build, and browser smoke checks passed.
