### PR TITLE
Fixes the download button becoming inaccessible on mobile when the user has increased their browser or system text size.

### DIFF
--- a/src/client/lazy-app/Compress/Results/style.css
+++ b/src/client/lazy-app/Compress/Results/style.css
@@ -28,7 +28,7 @@
   background: rgba(0, 0, 0, 0.67);
   border-radius: 5px;
   display: grid;
-  grid-template-columns: max-content [bubble] 1fr [download] max-content;
+  grid-template-columns: max-content [bubble] minmax(0, 1fr) [download] max-content;
 
   @media (min-width: 600px) {
     --download-overflow-size: 30px;
@@ -71,10 +71,20 @@
 
 .bubble {
   align-self: center;
+  min-width: 0;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
 
   @media (min-width: 600px) {
     position: relative;
     width: max-content;
+    overflow-x: visible;
     grid-row: 1;
     grid-column: bubble;
 


### PR DESCRIPTION
Fixes the download button becoming inaccessible on mobile when the user has increased their browser or system text size.

## Changes

- Reserve a dedicated grid column for the download button.
- Allow only the result metadata section to scroll horizontally when its content overflows.
- Keep the existing mobile layout unchanged at normal text sizes.
- Hide the metadata scrollbar while preserving touch scrolling.
- Preserve the existing desktop layout and behavior.

## Testing

- Tested in the mobile layout at normal font size.
- Tested with increased text scaling.
- Confirmed the download button remains visible.
- Confirmed overflowing metadata can be scrolled horizontally.
- Confirmed no horizontal scrollbar appears at normal font size.

## Screenshot

Before:
<img width="416" height="907" alt="image" src="https://github.com/user-attachments/assets/488744aa-7de3-4a80-8c2e-04f04994a317" />

After:
<img width="422" height="912" alt="image" src="https://github.com/user-attachments/assets/b3b1ab4c-be59-486e-a04a-91830228447d" />


Fixes #1442 