### PR TITLE
Show a message when clipboard image paste fails

### DIFF
--- a/src/shared/prerendered-app/Intro/index.tsx
+++ b/src/shared/prerendered-app/Intro/index.tsx
@@ -211,7 +211,14 @@ export default class Intro extends Component<Props, State> {
       return;
     }
 
-    const blob = await getImageClipboardItem(clipboardItems);
+    let blob: Blob | undefined;
+
+    try {
+      blob = await getImageClipboardItem(clipboardItems);
+    } catch (err) {
+      this.props.showSnack!("Couldn't paste image from clipboard");
+      return;
+    }
 
     if (!blob) {
       this.props.showSnack!(`No image found in the clipboard`);


### PR DESCRIPTION
Fixes #637.

## Summary

Improve user feedback when an image cannot be retrieved from the clipboard.

## Changes

- Handle errors thrown while retrieving the clipboard image.
- Show a snackbar message when clipboard image retrieval fails.
- Preserve the existing message for cases where no image is present in the clipboard.

This keeps the existing clipboard flow unchanged while providing clear feedback for the previously unhandled failure case.