### PR TITLE
Offset small images from splitter handle

### DIFF
--- a/src/client/lazy-app/Compress/Output/index.tsx
+++ b/src/client/lazy-app/Compress/Output/index.tsx
@@ -46,6 +46,12 @@ const scaleToOpts: ScaleToOpts = {
   allowChangeEvent: true,
 };
 
+const splitterHandleSize = 62;
+
+function needsSplitterOffset(image?: ImageData): boolean {
+  return !!image && Math.max(image.width, image.height) < splitterHandleSize;
+}
+
 export default class Output extends Component<Props, State> {
   state: State = {
     scale: 1,
@@ -268,6 +274,8 @@ export default class Output extends Component<Props, State> {
   ) {
     const leftDraw = this.leftDrawable();
     const rightDraw = this.rightDrawable();
+    const leftNeedsSplitterOffset = needsSplitterOffset(leftDraw);
+    const rightNeedsSplitterOffset = needsSplitterOffset(rightDraw);
     // To keep position stable, the output is put in a square using the longest dimension.
     const originalImage = source && source.preprocessed;
 
@@ -299,8 +307,8 @@ export default class Output extends Component<Props, State> {
             >
               <canvas
                 class={`${style.pinchTarget} ${
-                  aliasing ? style.pixelated : ''
-                }`}
+                  leftNeedsSplitterOffset ? style.smallImage : ''
+                } ${aliasing ? style.pixelated : ''}`}
                 ref={linkRef(this, 'canvasLeft')}
                 width={leftDraw && leftDraw.width}
                 height={leftDraw && leftDraw.height}
@@ -317,8 +325,8 @@ export default class Output extends Component<Props, State> {
             >
               <canvas
                 class={`${style.pinchTarget} ${
-                  aliasing ? style.pixelated : ''
-                }`}
+                  rightNeedsSplitterOffset ? style.smallImage : ''
+                } ${aliasing ? style.pixelated : ''}`}
                 ref={linkRef(this, 'canvasRight')}
                 width={rightDraw && rightDraw.width}
                 height={rightDraw && rightDraw.height}

--- a/src/client/lazy-app/Compress/Output/style.css
+++ b/src/client/lazy-app/Compress/Output/style.css
@@ -39,6 +39,12 @@
   flex-shrink: 0;
 }
 
+@media (min-width: 860px) {
+  .small-image {
+    margin-bottom: calc(var(--thumb-size) * 2);
+  }
+}
+
 .controls {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Fixes #647.

## Summary

Prevent very small images from being obscured by the splitter handle.

## Changes

- Detect images smaller than the splitter handle.
- Apply a dedicated offset to those images.
- Limit the offset styling to larger screens.

Normal-sized images and the existing splitter behavior remain unchanged.