### PR TITLE
Apply typed zoom after editing completes

### DIFF
--- a/src/client/lazy-app/Compress/Output/index.tsx
+++ b/src/client/lazy-app/Compress/Output/index.tsx
@@ -345,7 +345,7 @@ export default class Output extends Component<Props, State> {
                 ref={linkRef(this, 'scaleInput')}
                 class={style.zoom}
                 value={Math.round(scale * 100)}
-                onInput={this.onScaleInputChanged}
+                onChange={this.onScaleInputChanged}
                 onBlur={this.onScaleInputBlur}
               />
             ) : (


### PR DESCRIPTION
Fixes #1064.

## Summary

Apply typed zoom values when editing the zoom input is complete.

## Changes

- Change the zoom input handler from `onInput` to `onChange`.
- Allow the existing zoom/blur handling to operate after the entered value has been committed.

This is a minimal change to the existing zoom input behavior and addresses the issue where typing a zoom value could leave the image incorrectly positioned.