### PR TITLE
Watch generated codec assets

### DIFF
--- a/lib/simple-ts.js
+++ b/lib/simple-ts.js
@@ -47,7 +47,12 @@ export default function simpleTS(mainPath, { noBuild, watch } = {}) {
   let tsBuildDone;
 
   async function watchBuiltFiles(rollupContext) {
-    const matches = await globP(config.options.outDir + '/**/*.js');
+    const matches = (
+      await Promise.all([
+        globP(config.options.outDir + '/**/*.js'),
+        globP('codecs/**/*.{wasm,d.ts}'),
+      ])
+    ).flat();
     for (const match of matches) rollupContext.addWatchFile(match);
   }
 


### PR DESCRIPTION
Fixes #856.

## Summary

Update the development build watcher to track generated codec assets.

## Changes

- Continue watching generated JavaScript files in the build output.
- Also watch generated `.wasm` and `.d.ts` files under `codecs/`.
- Register all matching files with Rollup so changes trigger the existing watch workflow.

This keeps generated codec assets in the development watch cycle without changing the normal build behavior.