### PR TITLE
Use SVG viewBox for percentage dimensions

### DIFF
--- a/src/client/lazy-app/Compress/index.tsx
+++ b/src/client/lazy-app/Compress/index.tsx
@@ -227,14 +227,16 @@ async function processSvg(
   const document = parser.parseFromString(text, 'image/svg+xml');
   const svg = document.documentElement!;
 
-  if (svg.hasAttribute('width') && svg.hasAttribute('height')) {
+  const width = svg.getAttribute('width');
+  const height = svg.getAttribute('height');
+  if (width && height && !width.endsWith('%') && !height.endsWith('%')) {
     return blobToImg(blob);
   }
 
   const viewBox = svg.getAttribute('viewBox');
   if (viewBox === null) throw Error('SVG must have width/height or viewBox');
 
-  const viewboxParts = viewBox.split(/\s+/);
+  const viewboxParts = viewBox.trim().split(/[\s,]+/);
   svg.setAttribute('width', viewboxParts[2]);
   svg.setAttribute('height', viewboxParts[3]);
 


### PR DESCRIPTION
Fixes #530.

## Summary

Fix SVG scaling when `width` and `height` are specified as percentages.

## Changes

- Preserve the existing SVG dimensions when `width` and `height` are explicit non-percentage values.
- Fall back to the SVG `viewBox` when either dimension uses a percentage.
- Improve `viewBox` parsing to support both whitespace- and comma-separated values.

This allows SVGs using percentage-based dimensions to derive their rendered size from the `viewBox` instead of treating the percentage dimensions as fixed values.