### PR TITLE
Add alpha-only palette reduction

### DIFF
--- a/src/features/processors/quantize/client/index.tsx
+++ b/src/features/processors/quantize/client/index.tsx
@@ -1,4 +1,4 @@
-import { h, Component } from 'preact';
+import { h, Component, Fragment } from 'preact';
 import { Options as QuantizeOptions } from '../shared/meta';
 import * as style from 'client/lazy-app/Compress/Options/style.css';
 import {
@@ -9,6 +9,7 @@ import {
 import Expander from 'client/lazy-app/Compress/Options/Expander';
 import Select from 'client/lazy-app/Compress/Options/Select';
 import Range from 'client/lazy-app/Compress/Options/Range';
+import Checkbox from 'client/lazy-app/Compress/Options/Checkbox';
 
 const konamiPromise = konami();
 
@@ -38,6 +39,7 @@ export class Options extends Component<Props, State> {
 
     const newOptions: QuantizeOptions = {
       zx: inputFieldValueAsNumber(form.zx, options.zx),
+      alphaOnly: !!form.alphaOnly && form.alphaOnly.checked,
       maxNumColors: inputFieldValueAsNumber(
         form.maxNumColors,
         options.maxNumColors,
@@ -67,17 +69,27 @@ export class Options extends Component<Props, State> {
         </Expander>
         <Expander>
           {options.zx ? null : (
-            <div class={style.optionOneCell}>
-              <Range
-                name="maxNumColors"
-                min="2"
-                max="256"
-                value={options.maxNumColors}
-                onInput={this.onChange}
-              >
-                Colors:
-              </Range>
-            </div>
+            <Fragment>
+              <div class={style.optionOneCell}>
+                <Range
+                  name="maxNumColors"
+                  min="2"
+                  max="256"
+                  value={options.maxNumColors}
+                  onInput={this.onChange}
+                >
+                  Colors:
+                </Range>
+              </div>
+              <label class={style.optionToggle}>
+                Alpha only
+                <Checkbox
+                  name="alphaOnly"
+                  checked={options.alphaOnly}
+                  onChange={this.onChange}
+                />
+              </label>
+            </Fragment>
           )}
         </Expander>
         <div class={style.optionOneCell}>

--- a/src/features/processors/quantize/shared/meta.ts
+++ b/src/features/processors/quantize/shared/meta.ts
@@ -12,12 +12,14 @@
  */
 export interface Options {
   zx: number;
+  alphaOnly: boolean;
   maxNumColors: number;
   dither: number;
 }
 
 export const defaultOptions: Options = {
   zx: 0,
+  alphaOnly: false,
   maxNumColors: 256,
   dither: 1.0,
 };

--- a/src/features/processors/quantize/worker/quantize.ts
+++ b/src/features/processors/quantize/worker/quantize.ts
@@ -16,6 +16,37 @@ import { Options } from '../shared/meta';
 
 let emscriptenModule: Promise<QuantizerModule>;
 
+function alphaQuantize(
+  module: QuantizerModule,
+  data: ImageData,
+  opts: Options,
+): Uint8ClampedArray {
+  const alphaData = new Uint8ClampedArray(data.data.length);
+
+  for (let i = 0; i < data.data.length; i += 4) {
+    alphaData[i] = alphaData[i + 1] = alphaData[i + 2] = data.data[i + 3];
+    alphaData[i + 3] = 255;
+  }
+
+  const result = module.quantize(
+    alphaData,
+    data.width,
+    data.height,
+    opts.maxNumColors,
+    opts.dither,
+  );
+
+  for (let i = 0; i < result.length; i += 4) {
+    const alpha = result[i];
+    result[i] = data.data[i];
+    result[i + 1] = data.data[i + 1];
+    result[i + 2] = data.data[i + 2];
+    result[i + 3] = alpha;
+  }
+
+  return result;
+}
+
 export default async function process(
   data: ImageData,
   opts: Options,
@@ -28,6 +59,8 @@ export default async function process(
 
   const result = opts.zx
     ? module.zx_quantize(data.data, data.width, data.height, opts.dither)
+    : opts.alphaOnly
+    ? alphaQuantize(module, data, opts)
     : module.quantize(
         data.data,
         data.width,


### PR DESCRIPTION
Fixes #819.

## Summary

Add an optional alpha-only palette reduction mode for images.

## Changes

- Add an `Alpha only` option to the palette reduction settings.
- Preserve the existing color channels while reducing the number of alpha levels.
- Apply the existing quantizer to the alpha channel and restore the original RGB values.
- Keep the existing quantization behavior unchanged when `Alpha only` is disabled.

This provides a way to reduce alpha-channel complexity while preserving the image's original colors.